### PR TITLE
LazyTensor implementation + bring back inplacing/shared objects

### DIFF
--- a/crates/ratchet-core/src/backprop.rs
+++ b/crates/ratchet-core/src/backprop.rs
@@ -175,7 +175,7 @@ impl Tensor {
                     }
                     LazyOp::IndexWrite(_) => todo!(),
                     LazyOp::Cast(_) => todo!(),
-                    // LazyOp::Copy(_) => todo!(),
+                    LazyOp::Copy(_) => todo!(),
                     LazyOp::Detach(_)
                     | LazyOp::Const
                     | LazyOp::RoPE(_)
@@ -706,6 +706,7 @@ impl Tensor {
                 LazyOp::IndexWrite(_) => todo!(),
                 LazyOp::IndexAdd(_) => todo!(),
                 LazyOp::Cache(_) => todo!(),
+                LazyOp::Copy(_) => todo!(),
             };
         }
         #[cfg(feature = "plotting")]

--- a/crates/ratchet-core/src/backprop.rs
+++ b/crates/ratchet-core/src/backprop.rs
@@ -508,6 +508,18 @@ impl Tensor {
                     op: UnaryOp::Relu,
                 }) => {
                     let sum_grad = grads.or_insert(arg.clone())?;
+                    let relu_grad = arg.clone().affine(2.0, 0.0)?.mul(
+                        arg.clone()
+                            .ge(arg.clone().zeros_like::<f32>())?
+                            .cast(arg.dt())?,
+                    )?;
+                    *sum_grad = sum_grad.clone().add((grad * relu_grad)?)?;
+                }
+                LazyOp::Unary(Unary {
+                    input: arg,
+                    op: UnaryOp::Relu2,
+                }) => {
+                    let sum_grad = grads.or_insert(arg.clone())?;
                     let relu_grad = arg
                         .clone()
                         .ge(arg.clone().zeros_like::<f32>())?

--- a/crates/ratchet-core/src/backprop.rs
+++ b/crates/ratchet-core/src/backprop.rs
@@ -5,7 +5,7 @@ use crate::ops::{BinaryOp, UnaryOp};
 use crate::{
     rvec, Affine, Binary, Broadcast, Cmp, Concat, Conv, DType, Gather, GroupNorm, IndexAdd,
     IndexSelect, LazyOp, Matmul, Norm, NormOp, Permute, Powf, Reduce, ReduceOp, Reindex,
-    ScatterAdd, Shape, Slice, Softmax, Tensor, TensorId, Unary, View, WgpuDevice, WhereCond,
+    ScatterAdd, Shape, Slice, Softmax, Tensor, TensorId, Unary, View, WhereCond,
 };
 use crate::{HashMap, Trilu};
 use anyhow::Result;
@@ -753,21 +753,6 @@ impl GradStore {
 
     pub fn iter_mut(&mut self) -> impl Iterator<Item = (&TensorId, &mut Tensor)> {
         self.0.iter_mut()
-    }
-
-    pub fn resolve(&mut self, device: &WgpuDevice) -> Result<()> {
-        // TODO(vinhowe): device is currently unused, but we expect to use it once it manages
-        // order/graph caching state. execution_order is one of the most expensive things we're doing
-        // —not GPU operations.
-
-        // Replace each gradient tensor with its resolved version
-        for (_, grad) in self.iter_mut() {
-            if !grad.resolved() {
-                *grad = grad.clone().resolve_deferred()?;
-            }
-        }
-        // device.poll(wgpu::MaintainBase::Wait);
-        Ok(())
     }
 
     /// Get the gradient tensor associated with the given tensor, or, if it does not exist,

--- a/crates/ratchet-core/src/compiled_op.rs
+++ b/crates/ratchet-core/src/compiled_op.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "debug")]
+use crate::gpu::BindGroupLayoutEntryDescriptor;
 use crate::gpu::{
     BindGroupDescriptor, BindGroupLayoutHandle, ComputePipelineHandle, GpuBindGroup, WgpuDevice,
     WorkgroupCount,
@@ -6,7 +8,6 @@ use crate::gpu::{
 use crate::TensorId;
 use crate::{drvec, rvec, KernelKey, OperationError, PooledGPUBuffer, RVec, Tensor};
 use derive_new::new;
-#[cfg(feature = "debug")]
 use std::sync::Arc;
 use wgpu::DynamicOffset;
 
@@ -32,19 +33,20 @@ impl CompiledCopy {
 }
 
 //Compiled op represents a single kernel invocation
-//TODO: We need to be more general here, enum with encoder.copy_buffer_to_buffer as a COPY, and
-//compiledOp as compute
 #[derive(Debug, new)]
 pub struct CompiledOp {
-    pipeline_handle: ComputePipelineHandle,
-    workgroup_count: WorkgroupCount,
-    storage_groups: RVec<GpuBindGroup>,
-    offset: DynamicOffset, //offset into the metadata uniform buffer
+    pub(crate) pipeline_handle: ComputePipelineHandle,
+    pub(crate) workgroup_count: WorkgroupCount,
+    pub(crate) storage_groups: RVec<GpuBindGroup>,
+    pub(crate) offset: DynamicOffset, //offset into the metadata uniform buffer
     pub kernel_key: KernelKey,
     #[cfg(feature = "debug")]
     pub debug_buffer: Option<(TensorId, Arc<wgpu::Buffer>)>,
     #[cfg(feature = "debug")]
     pub debug_input_buffers: Option<RVec<(TensorId, Arc<wgpu::Buffer>)>>,
+    #[cfg(feature = "debug")]
+    pub storage_bind_group_layout_entries: RVec<BindGroupLayoutEntryDescriptor>,
+}
 
 #[derive(Debug)]
 pub enum Compiled {

--- a/crates/ratchet-core/src/compiled_op.rs
+++ b/crates/ratchet-core/src/compiled_op.rs
@@ -4,11 +4,32 @@ use crate::gpu::{
 };
 #[cfg(feature = "debug")]
 use crate::TensorId;
-use crate::{drvec, rvec, KernelKey, OperationError, RVec, Tensor};
+use crate::{drvec, rvec, KernelKey, OperationError, PooledGPUBuffer, RVec, Tensor};
 use derive_new::new;
 #[cfg(feature = "debug")]
 use std::sync::Arc;
 use wgpu::DynamicOffset;
+
+#[derive(Debug, new)]
+pub struct CompiledCopy {
+    src: Arc<PooledGPUBuffer>,
+    dst: Arc<PooledGPUBuffer>,
+    size: u64,
+}
+
+impl CompiledCopy {
+    pub fn src(&self) -> &Arc<PooledGPUBuffer> {
+        &self.src
+    }
+
+    pub fn dst(&self) -> &Arc<PooledGPUBuffer> {
+        &self.dst
+    }
+
+    pub fn size(&self) -> u64 {
+        self.size
+    }
+}
 
 //Compiled op represents a single kernel invocation
 //TODO: We need to be more general here, enum with encoder.copy_buffer_to_buffer as a COPY, and
@@ -24,6 +45,11 @@ pub struct CompiledOp {
     pub debug_buffer: Option<(TensorId, Arc<wgpu::Buffer>)>,
     #[cfg(feature = "debug")]
     pub debug_input_buffers: Option<RVec<(TensorId, Arc<wgpu::Buffer>)>>,
+
+#[derive(Debug)]
+pub enum Compiled {
+    Copy(CompiledCopy),
+    Compute(CompiledOp),
 }
 
 impl CompiledOp {

--- a/crates/ratchet-core/src/cpu/mod.rs
+++ b/crates/ratchet-core/src/cpu/mod.rs
@@ -47,6 +47,7 @@ pub fn apply_operation(op: LazyOp, dst: Tensor) -> Result<Tensor, OperationError
         LazyOp::IndexAdd(_i) => todo!(),
         LazyOp::ScatterAdd(_s) => todo!(),
         LazyOp::Detach(_d) => todo!(),
+        LazyOp::Copy(_c) => todo!(),
     }
 }
 

--- a/crates/ratchet-core/src/cpu/norm.rs
+++ b/crates/ratchet-core/src/cpu/norm.rs
@@ -141,7 +141,7 @@ where
         add(&mut x, &bias_b);
     }
 
-    cpu_store_result(&dst, &x);
+    cpu_store_result(dst, &x);
 
     Ok(())
 }
@@ -207,7 +207,7 @@ where
     let scale_b = broadcast(&scale, &shape!(N), src_shape);
     mul(&mut x, &scale_b);
 
-    cpu_store_result(&dst, &x);
+    cpu_store_result(dst, &x);
 
     Ok(())
 }

--- a/crates/ratchet-core/src/cpu/unary.rs
+++ b/crates/ratchet-core/src/cpu/unary.rs
@@ -59,6 +59,7 @@ macro_rules! impl_unary_ops {
             impl_cpu_unary_op!(square, |x: $dtype| x * x);
             impl_cpu_unary_op!(sqrt, |x: $dtype| x.sqrt());
             impl_cpu_unary_op!(relu, |x: $dtype| x.max($conv(0.0)));
+            impl_cpu_unary_op!(relu2, |x: $dtype| x.max($conv(0.0)) * x.max($conv(0.0)));
             impl_cpu_unary_op!(floor, |x: $dtype| x.floor());
             impl_cpu_unary_op!(ceil, |x: $dtype| x.ceil());
             impl_cpu_unary_op!(neg, |x: $dtype| -x);
@@ -78,6 +79,7 @@ macro_rules! impl_unary_ops {
                     UnaryOp::Square => Self::square(op.input(), dst),
                     UnaryOp::Sqrt => Self::sqrt(op.input(), dst),
                     UnaryOp::Relu => Self::relu(op.input(), dst),
+                    UnaryOp::Relu2 => Self::relu2(op.input(), dst),
                     UnaryOp::Floor => Self::floor(op.input(), dst),
                     UnaryOp::Ceil => Self::ceil(op.input(), dst),
                     UnaryOp::Neg => Self::neg(op.input(), dst),

--- a/crates/ratchet-core/src/dtype/blocks.rs
+++ b/crates/ratchet-core/src/dtype/blocks.rs
@@ -7,6 +7,7 @@ use crate::{rvec, Align, BufferSegment, DType, RVec, TensorDType};
 use derive_new::new;
 use half::f16;
 use num_traits::{AsPrimitive, Float, FromPrimitive, NumAssign};
+use std::hash::{Hash, Hasher};
 
 /// # Bindings
 ///
@@ -81,6 +82,16 @@ where
     }
 }
 
+macro_rules! impl_hash_q {
+    ($type:ty) => {
+        impl Hash for $type {
+            fn hash<H: Hasher>(&self, state: &mut H) {
+                self.0 .0.hash(state);
+            }
+        }
+    };
+}
+
 //We make these unit types for the sake of type safety.
 #[derive(Debug, Copy, Clone, PartialEq, Default)]
 pub struct Q8_0F(Q8_0<f32>);
@@ -91,6 +102,8 @@ impl Segments for Q8_0F {
     }
 }
 
+impl_hash_q!(Q8_0F);
+
 #[derive(Debug, Copy, Clone, PartialEq, Default)]
 pub struct Q8_0H(Q8_0<f16>);
 
@@ -99,6 +112,8 @@ impl Segments for Q8_0H {
         self.0.segments(numel)
     }
 }
+
+impl_hash_q!(Q8_0H);
 
 // ================== Q4 ==================
 #[derive(Debug, Clone, PartialEq)]
@@ -164,6 +179,9 @@ impl Segments for Q4_KH {
         self.0.segments(numel)
     }
 }
+
+impl_hash_q!(Q4_KH);
+impl_hash_q!(Q4_KF);
 
 pub trait Quantized {
     type FP: TensorDType + Float + NumAssign + AsPrimitive<i32> + FromPrimitive + Copy + PartialEq;

--- a/crates/ratchet-core/src/dtype/mod.rs
+++ b/crates/ratchet-core/src/dtype/mod.rs
@@ -8,7 +8,7 @@ use npyz::{DType as NpyDType, TypeStr};
 use std::{cmp::max, num::NonZeroU64};
 use wgpu::{BufferAddress, BufferSize};
 
-#[derive(Debug, Copy, Clone, PartialEq, Default)]
+#[derive(Debug, Copy, Clone, PartialEq, Default, Hash)]
 pub enum DType {
     F16,
     BF16,

--- a/crates/ratchet-core/src/executable.rs
+++ b/crates/ratchet-core/src/executable.rs
@@ -1,24 +1,45 @@
 use crate::gpu::{GpuUniform, PoolError, StaticResourcePoolAccessor, WgpuDevice};
-use crate::CompiledOp;
-#[cfg(feature = "debug")]
+use crate::{Compiled, Storage};
+// #[cfg(feature = "debug")] (for tensor?)
 use crate::Tensor;
+#[cfg(feature = "debug")]
+use crate::{CPUBuffer, DType, HashMap, TensorId};
+#[cfg(feature = "debug")]
+use maybe_async::maybe_async;
+#[cfg(feature = "debug")]
+use parking_lot::RwLock;
+#[cfg(feature = "debug")]
+use slotmap::Key;
+#[cfg(feature = "debug")]
+use std::sync::Arc;
+
+#[cfg(feature = "debug")]
+use crate::{wgpu_buffer_to_cpu_buffer, DeviceStorage, KernelKey, RVec};
 use derive_new::new;
-#[cfg(not(feature = "debug"))]
-use std::marker::PhantomData;
 use wgpu::SubmissionIndex;
+
+#[cfg(feature = "debug")]
+#[derive(new, Debug, Clone)]
+pub struct DebugTensor {
+    pub(crate) storage: Option<Storage>,
+    pub(crate) dtype: DType,
+    pub(crate) srcs: Vec<DebugTensor>,
+    pub(crate) size: usize,
+}
 
 /// # Executable
 ///
 /// A linear sequence of compiled operations, with a single uniform buffer
 /// containing metadata for all operations.
-#[derive(new)]
-pub struct Executable<'t> {
-    steps: Vec<CompiledOp>,
+#[derive(new, Debug)]
+pub struct Executable {
+    storage: Option<Vec<Option<Storage>>>,
+    pub(crate) steps: Vec<Compiled>,
     gpu_uniform: GpuUniform,
     #[cfg(feature = "debug")]
-    debug_list: Vec<&'t Tensor>,
-    #[cfg(not(feature = "debug"))]
-    _phantom: PhantomData<&'t ()>,
+    pub(crate) debug_list: Option<Vec<DebugTensor>>,
+    #[cfg(feature = "debug")]
+    pub(crate) cpu_bufs: Option<Arc<RwLock<HashMap<TensorId, CPUBuffer>>>>,
 }
 
 //this error ExecutionError
@@ -30,33 +51,82 @@ pub enum ExecutionError {
     DebuggingError(&'static str),
 }
 
-impl Executable<'_> {
+impl Executable {
     #[cfg(not(feature = "gpu-profiling"))]
     pub fn dispatch(&self, device: &WgpuDevice) -> Result<SubmissionIndex, ExecutionError> {
-        let pipeline_resources = device.pipeline_resources();
+        let pipeline_resources: crate::StaticResourcePoolReadLockAccessor<
+            '_,
+            crate::ComputePipelineHandle,
+            wgpu::ComputePipeline,
+        > = device.pipeline_resources();
         let mut encoder =
             device.create_command_encoder(&wgpu::CommandEncoderDescriptor { label: None });
 
-        {
-            let mut cpass = encoder.begin_compute_pass(&wgpu::ComputePassDescriptor {
-                label: Some("ratchet inference pass"),
-                timestamp_writes: None,
-            });
-            for step in self.steps.iter() {
-                cpass.set_pipeline(pipeline_resources.get(step.pipeline_handle())?);
+        // Create a peekable iterator over the steps.
+        let mut steps_iter = self.steps.iter().peekable();
 
-                for (group_index, bind_group) in step.storage_groups().iter().enumerate() {
-                    cpass.set_bind_group(group_index as u32, bind_group, &[]);
+        while let Some(step) = steps_iter.next() {
+            match step {
+                Compiled::Compute(op) => {
+                    // Start a new compute pass for contiguous compute operations.
+                    let mut cpass = encoder.begin_compute_pass(&wgpu::ComputePassDescriptor {
+                        label: Some("ratchet inference pass"),
+                        timestamp_writes: None,
+                    });
+
+                    // Process the current compute operation.
+                    cpass.set_pipeline(pipeline_resources.get(op.pipeline_handle())?);
+                    for (group_index, bind_group) in op.storage_groups().iter().enumerate() {
+                        cpass.set_bind_group(group_index as u32, bind_group, &[]);
+                    }
+                    let uniform_group_index = op.storage_groups().len() as u32;
+                    let uniform_group = self.gpu_uniform.bind_group();
+                    cpass.set_bind_group(uniform_group_index, uniform_group, &[op.offset()]);
+                    let [x_count, y_count, z_count] = op.workgroup_count().as_slice();
+                    cpass.dispatch_workgroups(x_count, y_count, z_count);
+
+                    // Consume all subsequent contiguous compute operations.
+                    while let Some(next_step) = steps_iter.peek() {
+                        if let Compiled::Compute(_) = next_step {
+                            // Consume this step.
+                            let next_op = if let Compiled::Compute(op) = steps_iter.next().unwrap()
+                            {
+                                op
+                            } else {
+                                unreachable!()
+                            };
+
+                            cpass.set_pipeline(pipeline_resources.get(next_op.pipeline_handle())?);
+                            for (group_index, bind_group) in
+                                next_op.storage_groups().iter().enumerate()
+                            {
+                                cpass.set_bind_group(group_index as u32, bind_group, &[]);
+                            }
+                            let uniform_group_index = next_op.storage_groups().len() as u32;
+                            let uniform_group = self.gpu_uniform.bind_group();
+                            cpass.set_bind_group(
+                                uniform_group_index,
+                                uniform_group,
+                                &[next_op.offset()],
+                            );
+                            let [x_count, y_count, z_count] = next_op.workgroup_count().as_slice();
+                            cpass.dispatch_workgroups(x_count, y_count, z_count);
+                        } else {
+                            break;
+                        }
+                    }
+                    // The compute pass is automatically ended when `cpass` goes out of scope.
                 }
-
-                let uniform_group_index = step.storage_groups().len() as u32;
-                let uniform_group = self.gpu_uniform.bind_group();
-                cpass.set_bind_group(uniform_group_index, uniform_group, &[step.offset()]);
-
-                let [x_count, y_count, z_count] = step.workgroup_count().as_slice();
-                cpass.dispatch_workgroups(x_count, y_count, z_count);
+                Compiled::Copy(op) => {
+                    // Process the copy operation outside of a compute pass.
+                    let src = op.src().as_ref();
+                    let dst = op.dst().as_ref();
+                    let size = op.size();
+                    encoder.copy_buffer_to_buffer(src, 0, dst, 0, size);
+                }
             }
         }
+
         Ok(device.queue().submit(Some(encoder.finish())))
     }
 
@@ -65,94 +135,185 @@ impl Executable<'_> {
         &self,
         device: &WgpuDevice,
     ) -> Result<SubmissionIndex, ExecutionError> {
-        use crate::{wgpu_buffer_to_cpu_buffer, DeviceStorage};
-
         let pipeline_resources = device.pipeline_resources();
-        assert!(self.debug_list.len() == self.steps.len());
-
-        let mut last_index = None;
-        for (step_index, step) in self.steps.iter().enumerate() {
-            let mut encoder =
-                device.create_command_encoder(&wgpu::CommandEncoderDescriptor { label: None });
-
-            {
-                let mut cpass = encoder.begin_compute_pass(&wgpu::ComputePassDescriptor {
-                    label: Some("ratchet inference pass"),
-                    timestamp_writes: None,
-                });
-                cpass.set_pipeline(pipeline_resources.get(step.pipeline_handle())?);
-
-                for (group_index, bind_group) in step.storage_groups().iter().enumerate() {
-                    cpass.set_bind_group(group_index as u32, bind_group, &[]);
-                }
-
-                let uniform_group_index = step.storage_groups().len() as u32;
-                let uniform_group = self.gpu_uniform.bind_group();
-                cpass.set_bind_group(uniform_group_index, uniform_group, &[step.offset()]);
-
-                let [x_count, y_count, z_count] = step.workgroup_count().as_slice();
-                cpass.dispatch_workgroups(x_count, y_count, z_count);
-            }
-
-            let result_t = self.debug_list[step_index].clone();
-            let gpu_storage = result_t.storage();
-            let result_buf = &gpu_storage
-                .as_ref()
-                .ok_or(ExecutionError::DebuggingError("Failed to get result buf."))?
-                .try_gpu()
-                .map_err(|_| ExecutionError::DebuggingError("Failed to get result buf."))?
-                .inner;
-
-            let input_storage_list = result_t
-                .op()
-                .srcs()
-                .iter()
-                .map(|s| {
-                    s.storage()
-                        .as_ref()
-                        .unwrap()
-                        .try_gpu()
-                        .unwrap()
-                        .inner
-                        .clone()
-                })
-                .collect::<Vec<_>>();
-            let debug_input_buffers =
-                step.debug_input_buffers
-                    .as_ref()
-                    .ok_or(ExecutionError::DebuggingError(
-                        "Failed to get input buffers.",
-                    ))?;
-            for (i, buf) in input_storage_list.iter().enumerate() {
-                let debug_input_buffer = debug_input_buffers[i].clone().1;
-                encoder.copy_buffer_to_buffer(buf, 0, &debug_input_buffer, 0, buf.size());
-            }
-
-            let (_, debug_buffer) =
-                step.debug_buffer
-                    .as_ref()
-                    .ok_or(ExecutionError::DebuggingError(
-                        "Failed to get debug buffer.",
-                    ))?;
-            encoder.copy_buffer_to_buffer(result_buf, 0, &debug_buffer, 0, debug_buffer.size());
-
-            let index = device.queue().submit(Some(encoder.finish()));
-            last_index = Some(index);
+        log::debug!(
+            "n steps: {}, n debug_list: {}",
+            self.steps.len(),
+            self.debug_list.as_ref().map(|d| d.len()).unwrap_or(0)
+        );
+        if let Some(debug_list) = &self.debug_list {
+            assert!(debug_list.len() == self.steps.len());
         }
 
-        //Dump all of our debug results
-        for (si, step) in self.steps.iter().enumerate() {
-            let d = device.clone();
-            let dt = self.debug_list[si].dt();
-            let (id, debug_buffer) = step.debug_buffer.clone().unwrap();
-            let debug_input_buffers = step.debug_input_buffers.clone().unwrap();
-            let alignment = dt.size_of();
-            let kernel_key = step.kernel_key.clone();
-            #[cfg(target_arch = "wasm32")]
-            {
-                wasm_bindgen_futures::spawn_local(async move {
+        let mut last_index = None;
+        // Create a peekable enumerated iterator over the steps.
+        let mut steps_iter = self.steps.iter().enumerate().peekable();
+
+        while let Some((step_index, step)) = steps_iter.next() {
+            match step {
+                Compiled::Compute(op) => {
+                    // Group contiguous compute operations.
+                    let mut compute_group = vec![(step_index, op)];
+                    while let Some(&(next_index, next_step)) = steps_iter.peek() {
+                        if let Compiled::Compute(next_op) = next_step {
+                            compute_group.push((next_index, next_op));
+                            steps_iter.next(); // Consume the op.
+                        } else {
+                            break;
+                        }
+                    }
+
+                    for &(step_index, op) in &compute_group {
+                        // Create a single encoder for the entire compute-group.
+                        let mut encoder =
+                            device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+                                label: None,
+                            });
+
+                        {
+                            // Begin a compute pass for all the grouped compute operations.
+                            let mut cpass =
+                                encoder.begin_compute_pass(&wgpu::ComputePassDescriptor {
+                                    label: Some("ratchet inference pass"),
+                                    timestamp_writes: None,
+                                });
+                            log::debug!(
+                                "Bind group layout entries: {} {:?} {:?}",
+                                op.kernel_key,
+                                op.storage_bind_group_layout_entries
+                                    .iter()
+                                    .map(|e| e.read_only)
+                                    .collect::<Vec<_>>(),
+                                &op.storage_groups()[0]
+                                    .descriptor()
+                                    .entries
+                                    .iter()
+                                    .map(|e| e.handle.data())
+                                    .collect::<Vec<_>>(),
+                            );
+                            cpass.set_pipeline(pipeline_resources.get(op.pipeline_handle())?);
+                            for (group_index, bind_group) in op.storage_groups().iter().enumerate()
+                            {
+                                cpass.set_bind_group(group_index as u32, bind_group, &[]);
+                            }
+                            let uniform_group_index = op.storage_groups().len() as u32;
+                            let uniform_group = self.gpu_uniform.bind_group();
+                            cpass.set_bind_group(
+                                uniform_group_index,
+                                uniform_group,
+                                &[op.offset()],
+                            );
+                            let [x_count, y_count, z_count] = op.workgroup_count().as_slice();
+                            cpass.dispatch_workgroups(x_count, y_count, z_count);
+                        }
+
+                        // Process the debugging copy operations associated with each compute op.
+                        if let Some(debug_list) = &self.debug_list {
+                            let result_t = debug_list[step_index].clone();
+                            let size = result_t.size;
+                            let gpu_storage = result_t.storage;
+                            let result_buf = &gpu_storage
+                                .as_ref()
+                                .ok_or(ExecutionError::DebuggingError("Failed to get result buf."))?
+                                .try_gpu()
+                                .map_err(|_| {
+                                    ExecutionError::DebuggingError("Result buf is not on GPU.")
+                                })?
+                                .inner;
+
+                            let input_storage_list = result_t
+                                .srcs
+                                .iter()
+                                .map(|s| {
+                                    (
+                                        s.storage
+                                            .as_ref()
+                                            .unwrap()
+                                            .try_gpu()
+                                            .unwrap()
+                                            .inner
+                                            .clone(),
+                                        s.size,
+                                    )
+                                })
+                                .collect::<Vec<_>>();
+                            let debug_input_buffers = op.debug_input_buffers.as_ref().ok_or(
+                                ExecutionError::DebuggingError("Failed to get input buffers."),
+                            )?;
+                            for (i, (buf, size)) in input_storage_list.iter().enumerate() {
+                                let debug_input_buffer = debug_input_buffers[i].clone().1;
+                                encoder.copy_buffer_to_buffer(
+                                    buf,
+                                    0,
+                                    &debug_input_buffer,
+                                    0,
+                                    *size as _,
+                                );
+                            }
+
+                            let (_, debug_buffer) =
+                                op.debug_buffer
+                                    .as_ref()
+                                    .ok_or(ExecutionError::DebuggingError(
+                                        "Failed to get debug buffer.",
+                                    ))?;
+                            encoder.copy_buffer_to_buffer(
+                                result_buf,
+                                0,
+                                debug_buffer,
+                                0,
+                                size as _,
+                            );
+                        }
+
+                        let index = device.queue().submit(Some(encoder.finish()));
+                        last_index = Some(index);
+                    }
+                }
+                Compiled::Copy(op) => {
+                    // Process copy operations individually.
+                    let mut encoder = device
+                        .create_command_encoder(&wgpu::CommandEncoderDescriptor { label: None });
+                    let src = op.src().as_ref();
+                    let dst = op.dst().as_ref();
+                    let size = op.size();
+                    encoder.copy_buffer_to_buffer(src, 0, dst, 0, size);
+                    last_index = Some(device.queue().submit(Some(encoder.finish())));
+                }
+            }
+        }
+
+        if let Some(debug_list) = &self.debug_list {
+            // Dump all of our debug results
+            for (si, step) in self.steps.iter().enumerate().filter_map(|(si, step)| {
+                if let Compiled::Compute(op) = step {
+                    Some((si, op))
+                } else {
+                    None
+                }
+            }) {
+                let d = device.clone();
+                let dt = debug_list[si].dtype;
+                let (id, debug_buffer) = step.debug_buffer.clone().unwrap();
+                let debug_input_buffers = step.debug_input_buffers.clone().unwrap();
+                let alignment = dt.size_of();
+                let kernel_key = step.kernel_key.clone();
+
+                #[allow(clippy::too_many_arguments)]
+                #[maybe_async]
+                async fn log_fn(
+                    si: usize,
+                    d: WgpuDevice,
+                    debug_buffer: &wgpu::Buffer,
+                    debug_input_buffers: RVec<(TensorId, Arc<wgpu::Buffer>)>,
+                    kernel_key: KernelKey,
+                    alignment: usize,
+                    id: TensorId,
+                    dt: DType,
+                    output_cpu_bufs: &Arc<RwLock<HashMap<TensorId, CPUBuffer>>>,
+                ) {
                     let cpu_buf =
-                        wgpu_buffer_to_cpu_buffer(&debug_buffer, alignment, None, &d).await;
+                        wgpu_buffer_to_cpu_buffer(debug_buffer, alignment, None, &d).await;
                     let mut input_bufs = vec![];
                     for (id, buf) in debug_input_buffers.iter() {
                         let cpu_buf = wgpu_buffer_to_cpu_buffer(buf, alignment, None, &d).await;
@@ -163,7 +324,7 @@ impl Executable<'_> {
                         si,
                         id,
                         kernel_key,
-                        cpu_buf.dump(dt, false)
+                        cpu_buf.dump(dt, (cpu_buf.n_bytes() / 4) <= 8)
                     );
 
                     for (i, (id, cpu_buf)) in input_bufs.iter().enumerate() {
@@ -171,17 +332,43 @@ impl Executable<'_> {
                             "\x1b[32;1minput {} ({:?})\x1b[0m: {:?}\n\n",
                             i,
                             id,
-                            cpu_buf.dump(dt, false)
+                            cpu_buf.dump(dt, (cpu_buf.n_bytes() / 4) <= 8)
                         ));
                     }
 
+                    output_cpu_bufs.write().insert(id, cpu_buf);
+
                     log::debug!("{}", debug_str);
-                });
-            }
-            #[cfg(not(target_arch = "wasm32"))]
-            {
-                let cpu_buf = wgpu_buffer_to_cpu_buffer(&debug_buffer, alignment, None, &d);
-                log::debug!("{}: {}\n {:?}\n", si, kernel_key, cpu_buf.dump(dt, false));
+                }
+
+                #[cfg(target_arch = "wasm32")]
+                {
+                    wasm_bindgen_futures::spawn_local(log_fn(
+                        si,
+                        d,
+                        debug_buffer,
+                        debug_input_buffers,
+                        kernel_key,
+                        alignment,
+                        id,
+                        dt,
+                        self.cpu_bufs.as_ref().unwrap(),
+                    ));
+                }
+                #[cfg(not(target_arch = "wasm32"))]
+                {
+                    log_fn(
+                        si,
+                        d,
+                        debug_buffer.as_ref(),
+                        debug_input_buffers,
+                        kernel_key,
+                        alignment,
+                        id,
+                        dt,
+                        self.cpu_bufs.as_ref().unwrap(),
+                    );
+                }
             }
         }
 
@@ -198,28 +385,62 @@ impl Executable<'_> {
         let pipeline_resources = device.pipeline_resources();
         let mut encoder =
             device.create_command_encoder(&wgpu::CommandEncoderDescriptor { label: None });
-
         let mut profiler = Profiler::new(device.clone(), self.steps.len() as _);
-        {
-            for step in self.steps.iter() {
-                let label = format!("{}_{}", step.kernel_key, step.workgroup_count().to_string());
-                let timestamp_writes = Some(profiler.create_timestamp_queries(0, label.as_str()));
-                let mut cpass = encoder.begin_compute_pass(&wgpu::ComputePassDescriptor {
-                    label: None,
-                    timestamp_writes,
-                });
-                cpass.set_pipeline(pipeline_resources.get(step.pipeline_handle())?);
 
-                for (group_index, bind_group) in step.storage_groups().iter().enumerate() {
-                    cpass.set_bind_group(group_index as u32, bind_group, &[]);
+        // Create a peekable iterator over steps.
+        let mut steps_iter = self.steps.iter().peekable();
+
+        while let Some(step) = steps_iter.next() {
+            match step {
+                Compiled::Compute(op) => {
+                    // Group all contiguous compute operations.
+                    let mut compute_group = vec![op];
+                    while let Some(next_step) = steps_iter.peek() {
+                        if let Compiled::Compute(next_op) = next_step {
+                            compute_group.push(next_op);
+                            steps_iter.next(); // consume the op
+                        } else {
+                            break;
+                        }
+                    }
+
+                    // Use the first op's label for the entire group.
+                    let first_op = compute_group.first().unwrap();
+                    let group_label = format!(
+                        "grouped: {} ({} ops)",
+                        first_op.kernel_key,
+                        compute_group.len()
+                    );
+                    let timestamp_writes =
+                        Some(profiler.create_timestamp_queries(0, group_label.as_str()));
+
+                    // Begin one compute pass for the grouped compute operations.
+                    let mut cpass = encoder.begin_compute_pass(&wgpu::ComputePassDescriptor {
+                        label: Some("ratchet inference pass"),
+                        timestamp_writes,
+                    });
+                    for op in compute_group {
+                        cpass.set_pipeline(pipeline_resources.get(op.pipeline_handle())?);
+                        for (group_index, bind_group) in op.storage_groups().iter().enumerate() {
+                            cpass.set_bind_group(group_index as u32, bind_group, &[]);
+                        }
+                        let uniform_group_index = op.storage_groups().len() as u32;
+                        let uniform_group = self.gpu_uniform.bind_group();
+                        cpass.set_bind_group(uniform_group_index, uniform_group, &[op.offset()]);
+                        let [x_count, y_count, z_count] = op.workgroup_count().as_slice();
+                        cpass.dispatch_workgroups(x_count, y_count, z_count);
+                    }
                 }
-
-                let uniform_group_index = step.storage_groups().len() as u32;
-                let uniform_group = self.gpu_uniform.bind_group();
-                cpass.set_bind_group(uniform_group_index, uniform_group, &[step.offset()]);
-
-                let [x_count, y_count, z_count] = step.workgroup_count().as_slice();
-                cpass.dispatch_workgroups(x_count, y_count, z_count);
+                Compiled::Copy(op) => {
+                    // Process copy operations individually.
+                    let mut encoder_copy = device
+                        .create_command_encoder(&wgpu::CommandEncoderDescriptor { label: None });
+                    let src = op.src().as_ref();
+                    let dst = op.dst().as_ref();
+                    let size = op.size();
+                    encoder_copy.copy_buffer_to_buffer(src, 0, dst, 0, size);
+                    let _ = device.queue().submit(Some(encoder_copy.finish()));
+                }
             }
         }
 
@@ -227,5 +448,45 @@ impl Executable<'_> {
         let index = device.queue().submit(Some(encoder.finish()));
         profiler.read_timestamps(true);
         Ok(index)
+    }
+
+    pub fn set_storage(&mut self, storage: Vec<Option<Storage>>) {
+        self.storage = Some(storage);
+    }
+
+    pub fn with_tensors(self, tensors: &Vec<&Tensor>) -> anyhow::Result<Self> {
+        assert_eq!(
+            tensors.len(),
+            self.storage.as_ref().unwrap().len(),
+            "Number of tensors must match number of storage slots"
+        );
+
+        // This doesn't work;
+        // - We need to update uniforms too
+        // - This logic doesn't totally make sense; I'm taking the storage from the existing run and
+        //   assigning it to the new tensors... is that fine?
+        for (storage, tensor) in self.storage.as_ref().unwrap().iter().zip(tensors) {
+            log::debug!("Setting storage for tensor: {:?}", tensor.id());
+            #[cfg(feature = "plotting")]
+            log::debug!(
+                "Storage: {:?}",
+                storage.as_ref().map(|s| s.plot_fmt().to_string())
+            );
+            if let Some(storage) = storage {
+                if !tensor.resolved() {
+                    tensor.update_storage(storage.clone());
+                }
+            }
+        }
+
+        Ok(Self {
+            storage: self.storage,
+            steps: self.steps,
+            gpu_uniform: self.gpu_uniform,
+            #[cfg(feature = "debug")]
+            debug_list: None,
+            #[cfg(feature = "debug")]
+            cpu_bufs: None,
+        })
     }
 }

--- a/crates/ratchet-core/src/gpu/align.rs
+++ b/crates/ratchet-core/src/gpu/align.rs
@@ -1,14 +1,14 @@
-///WebGPU is very specific about buffer alignment.
-///Since in Ratchet, any buffer may be copied back from GPU -> CPU, all buffers have a size
-///that is a multiple of COPY_BUFFER_ALIGNMENT (4 bytes).
-///
-///However, WebGPU also has more stringent alignment for storage buffer offsets.
-///This is controlled by `min_storage_buffer_offset_alignment` in wgpu::Limits.
-///This defaults to 256
-///
-///For quantized data types in Ratchet, each "segment" of quantized block (mins, scales, qs, zero
-///point etc.) is extracted and put into separate segments. Thus, these segments must be aligned to
-///256.
+//!WebGPU is very specific about buffer alignment.
+//!Since in Ratchet, any buffer may be copied back from GPU -> CPU, all buffers have a size
+//!that is a multiple of COPY_BUFFER_ALIGNMENT (4 bytes).
+//!
+//!However, WebGPU also has more stringent alignment for storage buffer offsets.
+//!This is controlled by `min_storage_buffer_offset_alignment` in wgpu::Limits.
+//!This defaults to 256
+//!
+//!For quantized data types in Ratchet, each "segment" of quantized block (mins, scales, qs, zero
+//!point etc.) is extracted and put into separate segments. Thus, these segments must be aligned to
+//!256.
 
 ///The `Align` trait provides methods to calculate the alignment of a usize, and to align a usize
 pub trait Align {

--- a/crates/ratchet-core/src/gpu/buffer_allocator/allocator.rs
+++ b/crates/ratchet-core/src/gpu/buffer_allocator/allocator.rs
@@ -1,15 +1,15 @@
 use super::TensorUsageRecord;
-use crate::HashMap;
 use crate::{
     gpu::{
         BufferDescriptor, BufferPool, BufferUsagesExt, CpuUniform, GpuBufferHandle,
         PooledGPUBuffer, TensorUsageRecords, WgpuDevice, UNIFORM_ALIGN,
     },
-    DeviceError, Tensor, TensorId,
+    DeviceError, GpuCompileKey, Tensor, TensorId,
 };
+use crate::{HashMap, LazyOp};
 use parking_lot::RwLock;
 use std::num::NonZero;
-use std::{borrow::Cow, sync::Arc};
+use std::{borrow::Cow, collections::BTreeMap};
 use wgpu::BufferUsages;
 
 #[derive(Clone, Debug, thiserror::Error)]
@@ -153,13 +153,27 @@ impl BufferAllocator {
     /// 2. If the operation has an inplace kernel available
     /// 3. If our PARENT (i.e the buffer we are about to apply an operation to) has multiple consumers
     ///    if it has multiple consumers, you can't inplace
-    fn determine_tensor_source(source: &Tensor) -> &Tensor {
-        let mut true_source = source;
+    fn determine_tensor_source<'a>(
+        source: &'a Tensor,
+        gpu_compile_keys: &HashMap<TensorId, GpuCompileKey>,
+    ) -> &'a Tensor {
+        let old_source_id = source.id();
+        let mut candidate = source;
+        log::trace!("Determining source for {:?}", old_source_id);
+
+        // If we start on a view, we need to iterate unconditionally
+        // until we find a non-view operation
+        while let LazyOp::View(_) = candidate.op() {
+            log::trace!("Stepping through view: {:?}", candidate.id());
+            candidate = candidate.op().srcs().first().unwrap();
+        }
+
+        let mut true_source = candidate;
+
         loop {
-            // vinhowe: we flip the inplace-by-default policy to make implementing training easier
-            if true_source.op().srcs().is_empty()
+            if candidate.op().srcs().is_empty()
                 || !true_source.op().supports_inplace()
-                || true_source.is_variable()
+                || candidate.is_variable()
             {
                 //If no sources, we are at the root
                 //Or if the operation doesn't support inplace
@@ -167,16 +181,34 @@ impl BufferAllocator {
             }
             //TODO: operations should define their "inplace" source
             //doesn't necessarily have to be the zeroth
-            let to_modify = true_source.op().srcs()[0];
-            if Arc::strong_count(&to_modify.inner) > 1 {
-                //If the source has multiple consumers, we can't inplace
-                //so we break here
+            let to_modify = candidate.op().srcs()[0];
+            log::trace!("To modify source: {:?}", to_modify.id());
+
+            if gpu_compile_keys
+                .get(&candidate.id())
+                .map(|key| !key.can_inplace())
+                .unwrap_or_else(|| !matches!(candidate.op(), LazyOp::View(_)))
+            {
                 break;
             }
-
-            true_source = to_modify;
+            if !matches!(to_modify.op(), LazyOp::View(_)) {
+                log::trace!("Found non-view source: {:?}", to_modify.id());
+                true_source = to_modify;
+            }
+            candidate = to_modify;
+            log::trace!("Candidate: {:?}", candidate.id());
         }
-        log::trace!("Traversed to true source: {:?}", true_source.id());
+
+        // If true source is a view, panic
+        if let LazyOp::View(_) = true_source.op() {
+            log::warn!("True source is a view: {:?}", true_source.id());
+        }
+
+        log::trace!(
+            "Traversed {:?} to true source: {:?}",
+            old_source_id,
+            true_source.id()
+        );
         true_source
     }
 
@@ -186,6 +218,7 @@ impl BufferAllocator {
     //3. When we encounter the producer of a tensor, we stop recording the interval.
     fn calculate_usage_records(
         execution_order: &[&Tensor],
+        gpu_compile_keys: &HashMap<TensorId, GpuCompileKey>,
     ) -> HashMap<TensorId, TensorUsageRecord> {
         let mut records =
             HashMap::with_capacity_and_hasher(execution_order.len(), Default::default());
@@ -194,18 +227,19 @@ impl BufferAllocator {
             if t.resolved() {
                 continue;
             }
+
             for source in t.op().srcs() {
                 if source.resolved() {
                     continue;
                 }
-                let true_source = Self::determine_tensor_source(source);
+                let true_source = Self::determine_tensor_source(source, gpu_compile_keys);
                 records
                     .entry(true_source.id())
                     .or_insert_with(|| TensorUsageRecord {
                         id: None,
                         producer: None,
+                        is_variable: None,
                         last_consumer: topo_len - iter,
-                        #[cfg(debug_assertions)]
                         last_consumer_id: t.id(),
                         size: true_source.num_bytes(),
                     });
@@ -214,6 +248,7 @@ impl BufferAllocator {
             if let Some(record) = records.get_mut(&t.id()) {
                 record.id = Some(t.id());
                 record.producer = Some(topo_len - iter);
+                record.is_variable = Some(t.is_variable());
             }
         }
 
@@ -228,32 +263,44 @@ impl BufferAllocator {
     pub fn greedy_by_size(
         &self,
         execution_order: &[&Tensor],
+        output_tensors: &BTreeMap<TensorId, &Tensor>,
         assignments: &mut HashMap<TensorId, PooledGPUBuffer>,
+        gpu_compile_keys: &HashMap<TensorId, GpuCompileKey>,
+        use_shared_buffers: bool,
         device: &WgpuDevice,
     ) -> Result<(), DeviceError> {
-        let record_map = Self::calculate_usage_records(execution_order);
+        let record_map = Self::calculate_usage_records(execution_order, gpu_compile_keys);
         let records = TensorUsageRecords::from(record_map);
         let mut shared_objects: Vec<PooledGPUBuffer> = Vec::with_capacity(records.0.len());
 
         for record in records.0.iter() {
-            // let record_producer = record.producer.unwrap();
-            // let mut best_obj = None;
-            // for obj in shared_objects.iter() {
-            //     let mut suitable = true;
-            //     for inner_r in records.0.iter() {
-            //         let max_first = std::cmp::max(record_producer, inner_r.producer.unwrap());
-            //         let min_last = std::cmp::min(record.last_consumer, inner_r.last_consumer);
-            //         if max_first <= min_last && assignments.get(&inner_r.id.unwrap()) == Some(obj) {
-            //             suitable = false;
-            //             break;
-            //         }
-            //     }
-            //     if suitable {
-            //         best_obj = Some(obj);
-            //     }
-            // }
+            let should_be_shared = use_shared_buffers
+                && !(record.is_variable.unwrap_or(false)
+                    || output_tensors.get(&record.last_consumer_id).is_some());
 
-            let best_obj: Option<&PooledGPUBuffer> = None;
+            let mut best_obj = None;
+
+            if should_be_shared {
+                let record_producer = record.producer.unwrap();
+                for obj in shared_objects.iter() {
+                    let mut suitable = true;
+                    for inner_r in records.0.iter() {
+                        let max_first = std::cmp::max(record_producer, inner_r.producer.unwrap());
+                        let min_last = std::cmp::min(record.last_consumer, inner_r.last_consumer);
+                        if max_first <= min_last
+                            && assignments.get(&inner_r.id.unwrap()) == Some(obj)
+                        {
+                            suitable = false;
+                            break;
+                        }
+                    }
+                    if suitable {
+                        // log::debug!("Suitable for {:?}: {:?}", record.id.unwrap(), obj);
+                        best_obj = Some(obj);
+                    }
+                }
+            }
+
             if let Some(obj) = best_obj {
                 assignments.insert(record.id.unwrap(), (*obj).clone());
             } else {
@@ -264,7 +311,9 @@ impl BufferAllocator {
                     device,
                     false,
                 );
-                shared_objects.push(buf.clone());
+                if should_be_shared {
+                    shared_objects.push(buf.clone());
+                }
                 assignments.insert(record.id.unwrap(), buf);
             }
         }
@@ -275,7 +324,7 @@ impl BufferAllocator {
                 continue;
             }
             for source in t.op().srcs() {
-                let true_source = Self::determine_tensor_source(source);
+                let true_source = Self::determine_tensor_source(source, gpu_compile_keys);
                 if true_source.id() != source.id() {
                     if let Some(buf) = assignments.get(&true_source.id()) {
                         assignments.insert(source.id(), buf.clone());
@@ -304,6 +353,9 @@ impl BufferAllocator {
     pub fn allocate_cfg(
         &self,
         execution_order: &[&Tensor],
+        output_tensors: &BTreeMap<TensorId, &Tensor>,
+        gpu_compile_keys: &HashMap<TensorId, GpuCompileKey>,
+        use_shared_buffers: bool,
         device: &WgpuDevice,
     ) -> Result<HashMap<TensorId, PooledGPUBuffer>, DeviceError> {
         let mut free = Vec::with_capacity(execution_order.len()); //TODO: switch to BTreeMap
@@ -323,30 +375,59 @@ impl BufferAllocator {
         }
 
         //Allocate intermediates
-        self.greedy_by_size(execution_order, &mut assignments, device)?;
+        self.greedy_by_size(
+            execution_order,
+            output_tensors,
+            &mut assignments,
+            gpu_compile_keys,
+            use_shared_buffers,
+            device,
+        )?;
 
-        //The output tensor is a special case.
+        //The output tensors are a special case.
         //We know we need an allocation for the output.
         //We traverse upwards until we find the first non-inplace operation, and use it's buffer.
         //It's also handy to treat output as different, as we can handle getting data back to CPU
         //more efficiently in future.
-        let output = execution_order.last().unwrap();
-        let output_source = Self::determine_tensor_source(output);
-        let output_buffer = assignments
-            .get(&output_source.id())
-            .cloned()
-            .unwrap_or_else(|| {
-                self.graph_allocate(
-                    BufferDescriptor::new(
-                        output_source.num_bytes() as _,
-                        BufferUsages::standard(),
-                        false,
-                    ),
-                    &mut free,
-                    device,
-                )
-            });
-        assignments.insert(output.id(), output_buffer);
+        for output in output_tensors.values() {
+            log::debug!("Allocating output: {:?}", output.id());
+            let output_source = Self::determine_tensor_source(output, gpu_compile_keys);
+            let output_buffer = assignments
+                .get(&output_source.id())
+                .cloned()
+                .unwrap_or_else(|| {
+                    self.graph_allocate(
+                        BufferDescriptor::new(
+                            output_source.num_bytes() as _,
+                            BufferUsages::standard(),
+                            false,
+                        ),
+                        &mut free,
+                        device,
+                    )
+                });
+            assignments.insert(output.id(), output_buffer);
+        }
+
+        #[cfg(debug_assertions)]
+        {
+            let mut output_allocations = BTreeMap::new();
+            for t in execution_order.iter() {
+                if let Some(allocation) = assignments.get(&t.id()) {
+                    if output_tensors.contains_key(&t.id()) {
+                        output_allocations.insert(allocation.global_id(), t.id());
+                    } else if let Some(output_id) = output_allocations.get(&allocation.global_id())
+                    {
+                        panic!(
+                            "Allocation {:?} used by output tensor {:?} was reused by tensor {:?}",
+                            allocation.global_id(),
+                            output_id,
+                            t.id()
+                        );
+                    }
+                }
+            }
+        }
 
         log::debug!(
             "Total bytes allocated: {}kb",

--- a/crates/ratchet-core/src/gpu/buffer_allocator/lazy_graph_executor.rs
+++ b/crates/ratchet-core/src/gpu/buffer_allocator/lazy_graph_executor.rs
@@ -1,0 +1,646 @@
+use crate::{
+    CpuUniform, Executable, ExecutionError, GPUBuffer, HashMap, HashSet, Hasher as HasherType,
+    Inner, LazyOp, Storage, TensorError, WgpuDevice,
+};
+#[cfg(feature = "debug")]
+use crate::{DebugTensor, Device, DeviceStorage};
+use crate::{Tensor, TensorId};
+use parking_lot::RwLock;
+use std::collections::BTreeMap;
+use std::hash::{BuildHasherDefault, Hasher};
+use std::sync::{Arc, Weak};
+
+enum EmitStatus {
+    Emitting,
+    Emitted,
+}
+
+type EmissionMap = HashMap<TensorId, EmitStatus>;
+type PostOrderData<'a> = Vec<&'a Tensor>;
+
+struct CachedExecutable {
+    executable: Arc<Executable>,
+    shared_realloc: bool,
+}
+
+pub struct LazyGraphExecutor {
+    tensors: Arc<RwLock<BTreeMap<TensorId, Weak<Inner>>>>,
+    cache: HashMap<u64, CachedExecutable>,
+    pass_index: u64,
+    inplace_support: bool,
+}
+
+fn panic_cycle(id: TensorId) {
+    panic!(
+        "Cycle detected whilst computing topological order: {:?}. Try plotting with feature `plotting`.",
+        id
+    );
+}
+
+#[cfg(feature = "debug")]
+macro_rules! mut_in_debug {
+    ($ident:ident) => { mut $ident };
+}
+
+#[cfg(not(feature = "debug"))]
+macro_rules! mut_in_debug {
+    ($ident:ident) => {
+        $ident
+    };
+}
+
+fn compute_post_order(tensor: &Tensor) -> Vec<&Tensor> {
+    let mut post_order = Vec::new();
+    let mut node_stack = vec![tensor];
+    let mut emission_map = EmissionMap::default();
+    while let Some(node) = node_stack.last().cloned() {
+        match emission_map.get(&node.id()) {
+            None => {
+                emission_map.insert(node.id(), EmitStatus::Emitting);
+                for src in node.op().srcs() {
+                    if let Some(EmitStatus::Emitting) = emission_map.get(&src.id()) {
+                        panic_cycle(src.id());
+                    }
+
+                    node_stack.push(src);
+                }
+            }
+            Some(EmitStatus::Emitting) => {
+                for src in node.op().srcs() {
+                    if let Some(EmitStatus::Emitting) = emission_map.get(&src.id()) {
+                        panic_cycle(src.id());
+                    }
+                }
+                emission_map.insert(node.id(), EmitStatus::Emitted);
+                post_order.push(node);
+                node_stack.pop();
+            }
+            Some(EmitStatus::Emitted) => {
+                node_stack.pop();
+            }
+        }
+    }
+    post_order
+}
+
+fn compute_post_order_from_nodes(roots: Vec<&Tensor>) -> PostOrderData {
+    let mut post_order = Vec::new();
+    for root in roots {
+        post_order.extend(compute_post_order(root));
+    }
+    post_order
+}
+
+impl LazyGraphExecutor {
+    pub fn new(inplace_support: bool) -> Self {
+        Self {
+            tensors: Arc::new(RwLock::new(BTreeMap::default())),
+            cache: HashMap::default(),
+            pass_index: Default::default(),
+            inplace_support,
+        }
+    }
+
+    pub fn register_tensor(&self, tensor: &Tensor) {
+        log::trace!("Registering tensor {:?}", tensor.id());
+        self.tensors
+            .write()
+            .insert(tensor.id(), Arc::downgrade(&tensor.inner));
+    }
+
+    /// Unregisters a tensor by its `TensorId`.
+    pub fn unregister_tensor(&self, id: TensorId) {
+        log::trace!("Unregistering tensor {:?}", id);
+        self.tensors.write().remove(&id);
+    }
+
+    fn get_live_tensors(&self) -> BTreeMap<TensorId, Tensor> {
+        self.tensors
+            .read()
+            .iter()
+            // Attempt to upgrade from Weak<Inner> → Arc<Inner>.
+            // If it succeeds, wrap Arc<Inner> in Tensor.
+            .filter_map(|(id, weak_inner)| {
+                weak_inner
+                    .upgrade()
+                    .map(|arc_inner| (*id, Tensor { inner: arc_inner }))
+                    .filter(|(_, t)| !t.resolved())
+            })
+            .collect()
+    }
+
+    fn run_post_order<'a>(&self, tensors: Vec<&'a Tensor>) -> PostOrderData<'a> {
+        compute_post_order_from_nodes(tensors)
+    }
+
+    pub fn sync_live_tensors_graph(
+        &mut self,
+        gpu_device: &WgpuDevice,
+    ) -> anyhow::Result<(), TensorError> {
+        log::trace!("Syncing live tensors graph");
+        let tensors = self.get_live_tensors();
+        log::debug!("All registered IDs: {:?}", self.tensors.read().keys());
+        let owned_tensors = tensors.keys().cloned().collect();
+        self.sync_tensors_graph_impl(tensors, Some(owned_tensors), gpu_device, true)
+    }
+
+    pub fn sync_tensors_graph(
+        &mut self,
+        tensors: Vec<&Tensor>,
+        gpu_device: &WgpuDevice,
+    ) -> anyhow::Result<(), TensorError> {
+        self.sync_tensors_graph_impl(
+            tensors.into_iter().map(|t| (t.id(), t.clone())).collect(),
+            None,
+            gpu_device,
+            false,
+        )
+    }
+
+    fn run_executable(
+        &mut self,
+        executable: &Executable,
+        gpu_device: &WgpuDevice,
+        immediate: bool,
+    ) -> anyhow::Result<(), ExecutionError> {
+        log::debug!("Running executable");
+        #[cfg(feature = "debug")]
+        let index = executable.dispatch_debugging(gpu_device)?;
+
+        #[cfg(not(feature = "debug"))]
+        let index = executable.dispatch(gpu_device)?;
+
+        if immediate {
+            gpu_device.poll(wgpu::MaintainBase::WaitForSubmissionIndex(index));
+        }
+        Ok(())
+    }
+
+    fn sync_tensors_graph_impl(
+        &mut self,
+        tensors: BTreeMap<TensorId, Tensor>,
+        owned_tensors: Option<HashSet<TensorId>>,
+        gpu_device: &WgpuDevice,
+        use_cache: bool,
+    ) -> Result<(), TensorError> {
+        // First check if the tensors are already resolved
+        log::debug!("Syncing tensors graph");
+        if tensors.values().all(|t| t.resolved()) {
+            return Ok(());
+        }
+
+        // Notably, we compute post order first because we want to hash the tensors in post order,
+        // since each hash depends on the hashes of its sources. It's not clear to me that this
+        // violates some important unspoken assumption on the part of the LazyTensor authors.
+        // We also flip the hash order—post order first, then insertion order—because it's more
+        // convenient to treat it as one big hash pass.
+        // let tensors = tensors.clone();
+        let post_order = self.run_post_order(tensors.values().collect());
+
+        let mut indices = Vec::with_capacity(tensors.len());
+        let mut tensor_ids = HashSet::with_capacity_and_hasher(
+            tensors.len(),
+            BuildHasherDefault::<HasherType>::default(),
+        );
+
+        let mut hasher = HasherType::default();
+        let mut tensor_hashes = BTreeMap::default();
+
+        let mut consumed_tensors = HashSet::with_capacity_and_hasher(
+            tensors.len(),
+            BuildHasherDefault::<HasherType>::default(),
+        );
+
+        let mut uniform = CpuUniform::new();
+        let mut compile_keys = HashMap::default();
+        #[cfg(feature = "plotting")]
+        let mut strong_counts_inplace = HashMap::default();
+
+        // Keep track of the real source of each tensor; important to help resolve handle those
+        // annoying views correctly.
+        let mut tensor_sources = HashMap::default();
+
+        // First we loop over the post order to hash the tensors in the right order
+        for tensor in &post_order {
+            // Scope to drop tensor_hashes before inserting
+            let srcs = tensor.op().srcs();
+            log::trace!(
+                "{:?}: Srcs: {:?}",
+                tensor.id(),
+                srcs.iter().map(|s| s.id()).collect::<Vec<_>>()
+            );
+            let first_src = srcs.first().cloned();
+
+            let mut to_modify = None;
+            if !matches!(tensor.op(), LazyOp::View(_)) {
+                tensor_sources.insert(tensor.id(), tensor);
+                to_modify = first_src.map(|src| {
+                    tensor_sources
+                        .get(&src.id())
+                        .cloned()
+                        .expect("Source missing entry in tensor_sources")
+                });
+            } else if let Some(src) = tensor_sources
+                .get(&first_src.expect("All views should have one src").id())
+                .cloned()
+            {
+                tensor_sources.insert(tensor.id(), src);
+                to_modify = Some(src);
+            }
+
+            let can_inplace = match to_modify {
+                Some(to_modify_src) => {
+                    log::trace!(
+                        "{:?}: Supports inplace: {:?}, is variable: {:?}",
+                        tensor.id(),
+                        tensor.op().supports_inplace(),
+                        to_modify_src.is_variable()
+                    );
+
+                    if !self.inplace_support {
+                        match tensor.op() {
+                            LazyOp::Softmax(_) | LazyOp::ScatterAdd(_) | LazyOp::IndexAdd(_) => {
+                                true
+                            }
+                            LazyOp::Detach(d) => {
+                                matches!(
+                                    d.as_ref(),
+                                    LazyOp::Softmax(_)
+                                        | LazyOp::ScatterAdd(_)
+                                        | LazyOp::IndexAdd(_)
+                                )
+                            }
+                            _ => false,
+                        }
+                    } else if !tensor.op().supports_inplace()
+                    // vinhowe: we need to check if the src is a variable, because we can't
+                    // inplace variables unless we've disabled gradient tracking.
+                    || to_modify_src.is_variable()
+                    {
+                        false
+                    } else {
+                        // Typical references:
+                        // 1. Its original consumer. Whatever scope it was created in.
+                        // 2. `tensors`, as passed into this method, if it wasn't resolved and we
+                        //    upgraded its weak reference. This happens when we do a sync of live
+                        //    tensors, say, in an optimizer step, but a one-off sync won't do this.
+                        //    This is why we have the optional `owned_tensors`.
+                        // If these two are the only references, then we can inplace. Usually,
+                        // additional references include, not in any particular order:
+                        // 3. The optimizer, if it is a variable. We'll also check if the src is a
+                        //    variable.
+                        // 4+ Any other Tensor consumers in the post-order. If it's not a variable,
+                        //    these are the references we're concerned about messing with.
+                        //
+                        // If we own a copy, 2, otherwise 1.
+                        let expected_strong = owned_tensors
+                            .as_ref()
+                            .and_then(|ot| ot.contains(&to_modify_src.id()).then_some(2))
+                            .unwrap_or(1);
+
+                        to_modify_src.strong_count() == expected_strong
+                    }
+                }
+                None => false,
+            };
+
+            #[cfg(feature = "plotting")]
+            strong_counts_inplace.insert(tensor.id(), (tensor.strong_count(), can_inplace));
+            log::trace!(
+                "Can inplace: {:?}, op: {:?} ({:?}), strong: {:?}",
+                can_inplace,
+                tensor.op().name(),
+                tensor.id(),
+                to_modify.as_ref().map(|t| t.strong_count())
+            );
+            let compile_key = tensor.gpu_compile_key(can_inplace, &mut uniform);
+            let ir = tensor.op().ir();
+            ir.shape_hash(&mut hasher, &tensor_hashes, &compile_key);
+            if let Some(compile_key) = compile_key {
+                compile_keys.insert(tensor.id(), compile_key);
+            }
+            let hash = hasher.finish();
+            tensor_hashes.insert(tensor.id(), hash);
+            log::debug!("IR: {:?}", ir);
+            log::debug!("Tensor hash: {:#x} (op: {:?})", hash, tensor.op().name());
+            for src in tensor.op().srcs() {
+                consumed_tensors.insert(src.id());
+            }
+        }
+
+        log::debug!("Post-order hash: {:?}", hasher.finish());
+
+        let output_tensors = tensors
+            .iter()
+            .filter(|(id, _)| !consumed_tensors.contains(id))
+            .map(|(id, tensor)| (*id, tensor))
+            .collect::<BTreeMap<_, _>>();
+
+        #[cfg(feature = "plotting")]
+        crate::plot::render_to_file(
+            &post_order,
+            &output_tensors,
+            &strong_counts_inplace,
+            None,
+            construct_plot_filename("post_order", self.pass_index, self.inplace_support),
+        )
+        .unwrap();
+
+        for (i, (id, tensor)) in tensors.iter().enumerate() {
+            if !tensor_ids.insert(id) || tensor.resolved() {
+                continue;
+            }
+
+            #[cfg(feature = "debug")]
+            if !tensor_hashes.contains_key(id) {
+                log::warn!("Missing shape hash for tensor {:?}", id);
+                continue;
+            }
+            hasher.write_u64(
+                *tensor_hashes
+                    .get(id)
+                    .expect("Missing shape hash for tensor"),
+            );
+            indices.push(i);
+        }
+        let hash = hasher.finish();
+
+        log::debug!("Shape hash: {:?}", hash);
+
+        #[cfg(feature = "debug")]
+        let mut cpu_bufs = HashMap::default();
+
+        #[cfg(feature = "debug")]
+        // Get CPU buffers from existing allocations
+        for tensor in &post_order {
+            let storage_guard = tensor.storage();
+            match storage_guard.as_ref() {
+                Some(Storage::GPU(gpu_buf)) => {
+                    log::trace!("Getting CPU buffer for {:?}", tensor.id());
+                    cpu_bufs.insert(
+                        tensor.id(),
+                        gpu_buf.to_cpu(&Device::GPU(gpu_device.clone()))?,
+                    );
+                }
+                Some(Storage::CPU(cpu_buf)) => {
+                    log::trace!("Using existing CPU buffer for {:?}", tensor.id());
+                    cpu_bufs.insert(tensor.id(), cpu_buf.clone());
+                }
+                None => {}
+            }
+        }
+
+        let (mut cached_exec, do_shared_realloc) = if use_cache {
+            self.cache
+                .remove(&hash)
+                .map(|cached_exec| {
+                    if cached_exec.shared_realloc {
+                        (Arc::try_unwrap(cached_exec.executable).ok(), false)
+                    } else {
+                        (None, true)
+                    }
+                })
+                .unwrap_or((None, false))
+        } else {
+            (None, false)
+        };
+
+        let mut compiled_ops = Vec::with_capacity(post_order.len());
+
+        gpu_device.begin_pass(self.pass_index);
+
+        let mut allocations = if cached_exec.is_none() || do_shared_realloc {
+            Some(gpu_device.allocate_cfg(
+                &post_order,
+                &output_tensors,
+                &compile_keys,
+                do_shared_realloc,
+                gpu_device,
+            )?)
+        } else {
+            None
+        };
+
+        #[cfg(debug_assertions)]
+        log::debug!(
+            "Resolved tensors in post order: {:?}",
+            post_order
+                .iter()
+                .filter(|t| t.resolved())
+                .map(|t| t.id())
+                .collect::<Vec<_>>()
+        );
+
+        #[cfg(feature = "debug")]
+        let mut compute_dsts = Vec::new();
+
+        #[cfg(feature = "plotting")]
+        crate::plot::render_to_file(
+            &post_order,
+            &output_tensors,
+            &strong_counts_inplace,
+            None,
+            construct_plot_filename("prealloc", self.pass_index, self.inplace_support),
+        )
+        .unwrap();
+
+        for t in &post_order {
+            if t.op().is_const() || t.resolved() {
+                continue;
+            }
+
+            if let Some(allocations) = &mut allocations {
+                let id = t.id();
+                let inner = allocations.remove(&id).ok_or(TensorError::NoStorage(id))?;
+                t.update_storage(Storage::GPU(GPUBuffer {
+                    inner,
+                    alignment: t.dt().size_of(),
+                    cpu_size: Some(t.num_bytes()),
+                }));
+            }
+
+            if let Some(compile_key) = compile_keys.get(&t.id()) {
+                if cached_exec.is_some() {
+                    // TODO: Update debug things if needed here, otherwise, delete this branch
+                } else if let Some(compiled_op) =
+                    t.compile_gpu(compile_key, gpu_device, cfg!(feature = "debug"))
+                {
+                    compiled_ops.push(Some(compiled_op));
+                } else {
+                    log::warn!("Compilation failed for operation: {:?}", t.op().name());
+                    compiled_ops.push(None);
+                }
+
+                #[cfg(feature = "debug")]
+                compute_dsts.push((*t).clone());
+            }
+        }
+
+        // At this point we have a cached executable that we want to ignore.
+        cached_exec = cached_exec.map(|exec| exec.with_tensors(&post_order).unwrap());
+
+        #[cfg(feature = "debug")]
+        let debug_list = compute_dsts
+            .into_iter()
+            .map(|t| {
+                DebugTensor::new(
+                    t.storage().clone(),
+                    t.dt(),
+                    t.op()
+                        .srcs()
+                        .iter()
+                        .map(|s| {
+                            DebugTensor::new(s.storage().clone(), s.dt(), vec![], s.num_bytes())
+                        })
+                        .collect(),
+                    t.num_bytes(),
+                )
+            })
+            .collect::<Vec<_>>();
+
+        if use_cache {
+            if let Some(mut_in_debug!(cached_exec)) = cached_exec {
+                log::debug!("Using cached executable");
+
+                #[cfg(feature = "debug")]
+                let mut cpu_bufs = HashMap::default();
+
+                #[cfg(feature = "debug")]
+                // Get CPU buffers from existing allocations
+                for tensor in &post_order {
+                    let storage_guard = tensor.storage();
+                    match storage_guard.as_ref() {
+                        Some(Storage::GPU(gpu_buf)) => {
+                            log::trace!("Getting CPU buffer for {:?}", tensor.id());
+                            cpu_bufs.insert(
+                                tensor.id(),
+                                gpu_buf.to_cpu(&Device::GPU(gpu_device.clone()))?,
+                            );
+                        }
+                        Some(Storage::CPU(cpu_buf)) => {
+                            log::trace!("Using existing CPU buffer for {:?}", tensor.id());
+                            cpu_bufs.insert(tensor.id(), cpu_buf.clone());
+                        }
+                        None => {}
+                    }
+                }
+
+                #[cfg(feature = "debug")]
+                {
+                    cached_exec.debug_list = Some(debug_list);
+                    cached_exec.cpu_bufs = Some(Arc::new(RwLock::new(cpu_bufs)));
+                }
+
+                self.run_executable(&cached_exec, gpu_device, false)
+                    .unwrap();
+
+                #[cfg(all(feature = "debug", feature = "plotting"))]
+                {
+                    let cpu_bufs_guard = cached_exec.cpu_bufs.as_ref().map(|arc| arc.read());
+
+                    crate::plot::render_to_file(
+                        &post_order,
+                        &output_tensors,
+                        &strong_counts_inplace,
+                        cpu_bufs_guard.as_deref(),
+                        construct_plot_filename("post_exec", self.pass_index, self.inplace_support),
+                    )
+                    .unwrap();
+                }
+
+                self.cache.insert(
+                    hash,
+                    CachedExecutable {
+                        executable: Arc::new(cached_exec),
+                        shared_realloc: true,
+                    },
+                );
+                self.pass_index += 1;
+                return Ok(());
+            }
+
+            // On a cache miss: Clear cache because currently I don't know how to make sure
+            // allocations are compatible between runs.
+            self.cache.clear();
+        }
+
+        #[cfg(feature = "plotting")]
+        crate::plot::render_to_file(
+            &post_order,
+            &output_tensors,
+            &strong_counts_inplace,
+            None,
+            construct_plot_filename("alloc", self.pass_index, self.inplace_support),
+        )
+        .unwrap();
+
+        // Only keep the ops that successfully compiled.
+        let filtered_compiled_ops: Vec<_> = compiled_ops.into_iter().flatten().collect();
+
+        let mut executable = Executable::new(
+            None,
+            filtered_compiled_ops,
+            uniform.into_gpu(gpu_device)?,
+            #[cfg(feature = "debug")]
+            Some(debug_list),
+            #[cfg(feature = "debug")]
+            Some(Arc::new(RwLock::new(cpu_bufs))),
+        );
+
+        self.run_executable(&executable, gpu_device, false).unwrap();
+
+        #[cfg(all(feature = "debug", feature = "plotting"))]
+        {
+            let cpu_bufs_guard = executable.cpu_bufs.as_ref().map(|arc| arc.read());
+
+            crate::plot::render_to_file(
+                &post_order,
+                &output_tensors,
+                &strong_counts_inplace,
+                cpu_bufs_guard.as_deref(),
+                construct_plot_filename("post_exec", self.pass_index, self.inplace_support),
+            )
+            .unwrap();
+        }
+
+        executable.set_storage(post_order.iter().map(|t| t.storage().clone()).collect());
+
+        if use_cache {
+            // After creating/running the executable, we cache it
+            self.cache.insert(
+                hash,
+                CachedExecutable {
+                    executable: Arc::new(executable),
+                    shared_realloc: do_shared_realloc,
+                },
+            );
+        }
+
+        self.pass_index += 1;
+        Ok(())
+    }
+}
+
+impl Default for LazyGraphExecutor {
+    fn default() -> Self {
+        Self::new(false)
+    }
+}
+
+/// Constructs the plot filename with an optional "_inplace" segment.
+///
+/// The resulting filename is in the format:
+///   "<name>[_inplace]_<pass_index>.svg"
+///
+/// # Arguments
+/// * `name` - The base part of the file name (e.g., "post_order").
+/// * `pass_index` - The pass index used in the file name.
+/// * `inplace_support` - Flag indicating whether to add "_inplace" before the pass number.
+#[cfg(feature = "plotting")]
+fn construct_plot_filename(name: &str, pass_index: u64, inplace_support: bool) -> String {
+    if inplace_support {
+        format!("{}_inplace_{}", name, pass_index)
+    } else {
+        format!("{}_{}", name, pass_index)
+    }
+}

--- a/crates/ratchet-core/src/gpu/buffer_allocator/mod.rs
+++ b/crates/ratchet-core/src/gpu/buffer_allocator/mod.rs
@@ -1,5 +1,7 @@
 mod allocator;
+mod lazy_graph_executor;
 mod tensor_usage_record;
 
 pub use allocator::*;
+pub use lazy_graph_executor::*;
 pub use tensor_usage_record::*;

--- a/crates/ratchet-core/src/gpu/buffer_allocator/tensor_usage_record.rs
+++ b/crates/ratchet-core/src/gpu/buffer_allocator/tensor_usage_record.rs
@@ -9,9 +9,9 @@ pub struct TensorUsageRecord {
     pub id: Option<TensorId>,
     pub producer: Option<usize>,
     pub last_consumer: usize,
-    #[cfg(debug_assertions)]
     pub last_consumer_id: TensorId,
     pub size: usize,
+    pub is_variable: Option<bool>,
 }
 
 impl std::ops::Index<usize> for TensorUsageRecords {

--- a/crates/ratchet-core/src/gpu/pools/bind_group_layout_pool.rs
+++ b/crates/ratchet-core/src/gpu/pools/bind_group_layout_pool.rs
@@ -1,3 +1,7 @@
+use std::hash::Hash;
+#[cfg(feature = "debug")]
+use std::hash::Hasher;
+
 use crate::{gpu::WgpuDevice, rvec, RVec};
 
 use super::{static_resource_pool::StaticResourcePool, StaticResourcePoolReadLockAccessor};
@@ -37,18 +41,62 @@ impl BindGroupLayoutEntryExt for wgpu::BindGroupLayoutEntry {
 
 slotmap::new_key_type! { pub struct BindGroupLayoutHandle; }
 
+#[cfg(feature = "debug")]
+#[derive(Debug, Clone)]
+pub struct BindGroupLayoutEntryDescriptor {
+    pub entry: wgpu::BindGroupLayoutEntry,
+    pub read_only: bool,
+}
+
+#[cfg(feature = "debug")]
+impl Hash for BindGroupLayoutEntryDescriptor {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.entry.hash(state);
+    }
+}
+
+#[cfg(feature = "debug")]
+impl PartialEq for BindGroupLayoutEntryDescriptor {
+    fn eq(&self, other: &Self) -> bool {
+        self.entry == other.entry
+    }
+}
+
+#[cfg(feature = "debug")]
+impl Eq for BindGroupLayoutEntryDescriptor {}
+
+#[cfg(feature = "debug")]
+impl BindGroupLayoutEntryDescriptor {
+    pub fn compute_storage_buffer(binding: u32, read_only: bool) -> Self {
+        Self {
+            entry: wgpu::BindGroupLayoutEntry::compute_storage_buffer(binding, read_only),
+            read_only,
+        }
+    }
+
+    pub fn dynamic_uniform_buffer() -> Self {
+        Self {
+            entry: wgpu::BindGroupLayoutEntry::dynamic_uniform_buffer(),
+            read_only: true, // Uniform buffers are always read-only from shader perspective
+        }
+    }
+}
+
+#[cfg(not(feature = "debug"))]
+pub type BindGroupLayoutEntryDescriptor = wgpu::BindGroupLayoutEntry;
+
 #[derive(Debug, Clone, Hash, PartialEq, Eq, Default)]
 pub struct BindGroupLayoutDescriptor {
-    pub entries: RVec<wgpu::BindGroupLayoutEntry>,
+    pub entries: RVec<BindGroupLayoutEntryDescriptor>,
 }
 
 impl BindGroupLayoutDescriptor {
     //Used for unary, binary, ternary (NOT INPLACE)
-    fn entries(ro_length: usize) -> RVec<wgpu::BindGroupLayoutEntry> {
-        let mut read_only: RVec<wgpu::BindGroupLayoutEntry> = (0..ro_length)
-            .map(|idx| wgpu::BindGroupLayoutEntry::compute_storage_buffer(idx as u32, true))
+    fn entries(ro_length: usize) -> RVec<BindGroupLayoutEntryDescriptor> {
+        let mut read_only: RVec<BindGroupLayoutEntryDescriptor> = (0..ro_length)
+            .map(|idx| BindGroupLayoutEntryDescriptor::compute_storage_buffer(idx as u32, true))
             .collect();
-        read_only.push(wgpu::BindGroupLayoutEntry::compute_storage_buffer(
+        read_only.push(BindGroupLayoutEntryDescriptor::compute_storage_buffer(
             ro_length as u32,
             false,
         ));
@@ -63,7 +111,9 @@ impl BindGroupLayoutDescriptor {
 
     pub fn unary_inplace() -> Self {
         Self {
-            entries: rvec![wgpu::BindGroupLayoutEntry::compute_storage_buffer(0, false)],
+            entries: rvec![BindGroupLayoutEntryDescriptor::compute_storage_buffer(
+                0, false
+            )],
         }
     }
 
@@ -76,8 +126,8 @@ impl BindGroupLayoutDescriptor {
     pub fn binary_inplace() -> Self {
         Self {
             entries: rvec![
-                wgpu::BindGroupLayoutEntry::compute_storage_buffer(0, false),
-                wgpu::BindGroupLayoutEntry::compute_storage_buffer(1, true)
+                BindGroupLayoutEntryDescriptor::compute_storage_buffer(0, false),
+                BindGroupLayoutEntryDescriptor::compute_storage_buffer(1, true)
             ],
         }
     }
@@ -91,9 +141,9 @@ impl BindGroupLayoutDescriptor {
     pub fn ternary_inplace() -> Self {
         Self {
             entries: rvec![
-                wgpu::BindGroupLayoutEntry::compute_storage_buffer(0, false),
-                wgpu::BindGroupLayoutEntry::compute_storage_buffer(1, true),
-                wgpu::BindGroupLayoutEntry::compute_storage_buffer(2, true)
+                BindGroupLayoutEntryDescriptor::compute_storage_buffer(0, false),
+                BindGroupLayoutEntryDescriptor::compute_storage_buffer(1, true),
+                BindGroupLayoutEntryDescriptor::compute_storage_buffer(2, true)
             ],
         }
     }
@@ -106,7 +156,7 @@ impl BindGroupLayoutDescriptor {
 
     pub fn uniform() -> Self {
         Self {
-            entries: rvec![wgpu::BindGroupLayoutEntry::dynamic_uniform_buffer()],
+            entries: rvec![BindGroupLayoutEntryDescriptor::dynamic_uniform_buffer()],
         }
     }
 }
@@ -137,9 +187,13 @@ impl BindGroupLayoutPool {
         device: &WgpuDevice,
     ) -> BindGroupLayoutHandle {
         self.inner.get_or_create(descriptor, |desc| {
+            #[cfg(feature = "debug")]
+            let entries: Vec<_> = desc.entries.iter().map(|e| e.entry).collect();
+            #[cfg(not(feature = "debug"))]
+            let entries: Vec<_> = desc.entries.to_vec();
             device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
                 label: None,
-                entries: &desc.entries,
+                entries: &entries,
             })
         })
     }

--- a/crates/ratchet-core/src/gpu/pools/bind_group_pool.rs
+++ b/crates/ratchet-core/src/gpu/pools/bind_group_pool.rs
@@ -14,6 +14,13 @@ pub struct GpuBindGroup {
     _owned_buffers: RVec<PooledGPUBuffer>,
 }
 
+#[cfg(feature = "debug")]
+impl GpuBindGroup {
+    pub fn descriptor(&self) -> &BindGroupDescriptor {
+        &self.resource.descriptor
+    }
+}
+
 impl std::fmt::Debug for GpuBindGroup {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("GpuBindGroup")

--- a/crates/ratchet-core/src/gpu/pools/static_resource_pool.rs
+++ b/crates/ratchet-core/src/gpu/pools/static_resource_pool.rs
@@ -94,8 +94,8 @@ fn to_pool_error<T>(get_result: Option<T>, handle: impl Key) -> Result<T, PoolEr
     })
 }
 
-impl<'a, Handle: Key, Res> StaticResourcePoolAccessor<Handle, Res>
-    for StaticResourcePoolReadLockAccessor<'a, Handle, Res>
+impl<Handle: Key, Res> StaticResourcePoolAccessor<Handle, Res>
+    for StaticResourcePoolReadLockAccessor<'_, Handle, Res>
 {
     fn get(&self, handle: Handle) -> Result<&Res, PoolError> {
         to_pool_error(self.resources.get(handle), handle)

--- a/crates/ratchet-core/src/gpu/uniform.rs
+++ b/crates/ratchet-core/src/gpu/uniform.rs
@@ -52,6 +52,7 @@ impl CpuUniform {
     }
 }
 
+#[derive(Debug)]
 pub struct GpuUniform {
     buf: PooledGPUBuffer,
     bind_group: GpuBindGroup,

--- a/crates/ratchet-core/src/lib.rs
+++ b/crates/ratchet-core/src/lib.rs
@@ -32,7 +32,7 @@ pub use ndarray_ext::*;
 pub use op::*;
 pub use ops::*;
 pub use quant::*;
-use rustc_hash::{FxHashMap, FxHashSet};
+use rustc_hash::{FxHashMap, FxHashSet, FxHasher};
 pub use shape::*;
 pub use storage::*;
 pub use strides::*;
@@ -49,6 +49,7 @@ pub type DRVec<T> = SmallVec<[T; 8]>; //Double RVec
 pub type RawGPUBuffer = wgpu::Buffer;
 pub type HashMap<K, V> = FxHashMap<K, V>;
 pub type HashSet<T> = FxHashSet<T>;
+pub type Hasher = FxHasher;
 
 //https://github.com/sonos/tract/blob/main/data/src/macros.rs#L2
 #[macro_export]

--- a/crates/ratchet-core/src/op.rs
+++ b/crates/ratchet-core/src/op.rs
@@ -56,6 +56,7 @@ pub enum LazyOp {
     ScatterAdd(ScatterAdd),
     Trilu(Trilu),
     Arange(Arange),
+    Copy(TensorCopy),
     Detach(Box<LazyOp>), //Because the entire graph is lazy, you can't actually detach something without computing the graph in parts
 }
 
@@ -88,6 +89,7 @@ impl LazyOp {
             LazyOp::RoPE(r) => r.name(),
             LazyOp::Cache(c) => c.name(),
             LazyOp::View(v) => v.name(),
+            LazyOp::Copy(c) => c.name(),
             LazyOp::Const => "Const",
             LazyOp::Detach(d) => Box::leak(format!("Detach<{}>", d.name()).into_boxed_str()),
         }
@@ -120,6 +122,7 @@ impl LazyOp {
             LazyOp::Cache(c) => c.srcs(),
             LazyOp::Detach(d) => d.srcs(),
             LazyOp::View(v) => v.srcs(),
+            LazyOp::Copy(c) => c.srcs(),
             LazyOp::FillConstant(_) | LazyOp::FillRandn(_) | LazyOp::Arange(_) | LazyOp::Const => {
                 rvec![]
             } //end of the line kid
@@ -156,6 +159,7 @@ impl LazyOp {
             LazyOp::View(_v) => true,
             LazyOp::Const => false,
             LazyOp::Detach(d) => d.supports_inplace(),
+            LazyOp::Copy(c) => c.supports_inplace(),
         }
     }
 
@@ -198,6 +202,7 @@ impl LazyOp {
             LazyOp::View(v) => v.check_invariants(),
             LazyOp::Const => {}
             LazyOp::Detach(d) => d.check_invariants(),
+            LazyOp::Copy(c) => c.check_invariants(),
         }
     }
 

--- a/crates/ratchet-core/src/op.rs
+++ b/crates/ratchet-core/src/op.rs
@@ -4,18 +4,24 @@ use crate::gpu::{
     BindGroupLayoutDescriptor, ComputePipelineDescriptor, CpuUniform, PipelineLayoutDescriptor,
     PoolError, WgpuDevice,
 };
+#[cfg(feature = "debug")]
+use crate::MIN_STORAGE_BUFFER_SIZE;
 use crate::{
-    ops::*, rvec, CompiledOp, InvariantError, Kernel, KernelBuildError, KernelMetadata,
-    KernelModuleDesc, RVec, StorageView, Tensor, WgslFragment, WorkgroupSize,
+    ops::*, rvec, CompiledOp, DType, HashMap, InvariantError, Kernel, KernelBuildError,
+    KernelMetadata, KernelModuleDesc, RVec, Shape, StorageView, Tensor, TensorId, WgslFragment,
+    WorkgroupSize, Workload,
 };
 #[cfg(feature = "debug")]
-use crate::{TensorId, MIN_STORAGE_BUFFER_SIZE};
+use slotmap::Key;
 #[cfg(feature = "debug")]
 use smallvec::SmallVec;
 use std::borrow::Cow;
 #[cfg(feature = "debug")]
 use std::cmp::max;
+use std::collections::BTreeMap;
 use std::fmt::Debug;
+use std::hash::{Hash, Hasher};
+use std::ops::Range;
 #[cfg(feature = "debug")]
 use std::sync::Arc;
 
@@ -194,6 +200,45 @@ impl LazyOp {
             LazyOp::Detach(d) => d.check_invariants(),
         }
     }
+
+    pub(crate) fn ir(&self) -> Ir {
+        match self {
+            LazyOp::Binary(b) => b.ir(),
+            LazyOp::Cast(c) => c.ir(),
+            LazyOp::Matmul(m) => m.ir(),
+            LazyOp::RoPE(r) => r.ir(),
+            LazyOp::Softmax(s) => s.ir(),
+            LazyOp::Unary(u) => u.ir(),
+            LazyOp::Reindex(r) => r.ir(),
+            LazyOp::Concat(c) => c.ir(),
+            LazyOp::Norm(n) => n.ir(),
+            LazyOp::Affine(a) => a.ir(),
+            LazyOp::Cmp(c) => c.ir(),
+            LazyOp::Powf(p) => p.ir(),
+            LazyOp::WhereCond(w) => w.ir(),
+            LazyOp::Reduce(s) => s.ir(),
+            LazyOp::Gather(g) => g.ir(),
+            LazyOp::Conv(c) => c.ir(),
+            LazyOp::Select(s) => s.ir(),
+            LazyOp::IndexWrite(iw) => iw.ir(),
+            LazyOp::IndexAdd(ia) => ia.ir(),
+            LazyOp::ScatterAdd(sa) => sa.ir(),
+            LazyOp::Trilu(t) => t.ir(),
+            LazyOp::FillConstant(f) => f.ir(),
+            LazyOp::FillRandn(f) => f.ir(),
+            LazyOp::Arange(a) => a.ir(),
+            LazyOp::Cache(c) => c.ir(),
+            LazyOp::View(v) => v.ir(),
+            LazyOp::Detach(d) => {
+                let detached = d.ir();
+                let mut ir = Ir::new("Detach");
+                ir.with_field("op", detached);
+                ir
+            }
+            LazyOp::Const => Ir::new("Const"),
+            LazyOp::Copy(c) => c.ir(),
+        }
+    }
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -302,12 +347,318 @@ pub trait OpGuards {
     fn check_custom(&self) {}
 }
 
+#[derive(Debug)]
+pub enum IrScalarValue {
+    F32(f32),
+    I32(i32),
+    U32(u32),
+    Bool(bool),
+    String(String),
+    Vec4U32(glam::UVec4),
+}
+
+impl Hash for IrScalarValue {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        match self {
+            IrScalarValue::F32(f) => state.write_u32(f.to_bits()),
+            IrScalarValue::I32(i) => i.hash(state),
+            IrScalarValue::U32(u) => u.hash(state),
+            IrScalarValue::Bool(b) => b.hash(state),
+            IrScalarValue::String(s) => s.hash(state),
+            IrScalarValue::Vec4U32(v) => v.hash(state),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct IrTensorValue {
+    pub id: TensorId,
+    pub shape: Shape,
+    pub dtype: DType,
+}
+
+#[derive(Debug)]
+pub enum IrValue {
+    Scalar(IrScalarValue),
+    Tensor(IrTensorValue),
+    // This is used for Detach only
+    Ir(Ir),
+    // This should never actually exist on the IR; we use it to
+    // pull in a bunch of fields from a struct
+    Fields(Box<dyn IrFields>),
+    Vec(RVec<Box<IrValue>>),
+    // For optional fields
+    None,
+}
+
+#[derive(Debug)]
+pub struct Ir {
+    name: String,
+    fields: Option<HashMap<String, IrValue>>,
+}
+
+fn hash_key<H: Hasher>(key: &str, state: &mut H) {
+    state.write(key.as_bytes());
+}
+
+fn hash_ir_value<H: Hasher>(
+    value: &IrValue,
+    state: &mut H,
+    tensor_hashes: &BTreeMap<TensorId, u64>,
+    compile_key: &Option<GpuCompileKey>,
+) {
+    match value {
+        IrValue::Tensor(IrTensorValue { id, dtype, shape }) => {
+            let hash = tensor_hashes.get(id).unwrap();
+            hash.hash(state);
+            dtype.hash(state);
+            shape.hash(state);
+        }
+        IrValue::Ir(ir) => ir.shape_hash(state, tensor_hashes, compile_key),
+        // If list size changes, the IR changes. Can't think of a case where we wouldn't
+        // want this to be true...
+        IrValue::Vec(vec) => {
+            for (i, value) in vec.iter().enumerate() {
+                hash_key(&format!("{}", i), state);
+                hash_ir_value(value, state, tensor_hashes, compile_key);
+            }
+        }
+        // We don't hash scalar values or None values, relying on the compile key to
+        // differentiate them.
+        IrValue::Scalar(_) | IrValue::None => state.write_u64(0),
+        IrValue::Fields(_) => panic!("Fields should not be present in finalized op"),
+    }
+}
+
+impl Ir {
+    pub fn new(name: impl ToString) -> Self {
+        Self {
+            name: name.to_string(),
+            fields: None,
+        }
+    }
+
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    pub fn fields(&self) -> Option<&HashMap<String, IrValue>> {
+        self.fields.as_ref()
+    }
+
+    pub fn push_prefix(&mut self, prefix: impl ToString) {
+        self.name = format!("{}.{}", prefix.to_string(), self.name);
+    }
+
+    pub fn pop_prefix(&mut self) {
+        self.name = self.name.split('.').skip(1).collect::<Vec<_>>().join(".");
+    }
+
+    pub fn with_field(&mut self, name: impl ToString, value: impl Into<IrValue>) -> &mut Self {
+        let value = value.into();
+        let fields = self.fields.get_or_insert_default();
+        match value {
+            IrValue::Fields(fields) => {
+                self.push_prefix(name.to_string());
+                fields.ir_fields(self);
+                self.pop_prefix();
+            }
+            _ => {
+                fields.insert(name.to_string(), value);
+            }
+        };
+        self
+    }
+
+    pub fn shape_hash<H: Hasher>(
+        &self,
+        state: &mut H,
+        tensor_hashes: &BTreeMap<TensorId, u64>,
+        compile_key: &Option<GpuCompileKey>,
+    ) {
+        self.name.hash(state);
+        // We hash the compile key as our main differentiating factor.
+        // If it doesn't change the shader, the IR is the same.
+        if let Some(inner) = compile_key.as_ref() {
+            match inner {
+                GpuCompileKey::Compute(compute_key) => compute_key.key.hash(state),
+                GpuCompileKey::Copy(copy_key) => {
+                    hash_key("src", state);
+                    hash_ir_value(
+                        &copy_key.src.clone().into(),
+                        state,
+                        tensor_hashes,
+                        compile_key,
+                    );
+                    hash_key("dst", state);
+                    hash_ir_value(
+                        &copy_key.dst.clone().into(),
+                        state,
+                        tensor_hashes,
+                        compile_key,
+                    );
+                }
+            }
+        } else {
+            state.write_u64(0);
+        }
+
+        if let Some(fields) = &self.fields {
+            let mut fields = fields.iter().collect::<Vec<_>>();
+            fields.sort_by_key(|(k, _)| *k);
+
+            for (key, value) in fields {
+                hash_key(key, state);
+                hash_ir_value(value, state, tensor_hashes, compile_key);
+            }
+        }
+    }
+}
+
+/// # IR Fields
+///
+/// Allows describing fields of an operation for IR, which makes graph hashing possible.
+pub trait IrFields: Debug {
+    /// Add operation-specific fields to the IR description
+    fn ir_fields(&self, ir: &mut Ir);
+}
+
+impl<T: Into<IrValue>> From<Option<T>> for IrValue {
+    fn from(value: Option<T>) -> Self {
+        match value {
+            Some(tensor) => tensor.into(),
+            None => IrValue::None,
+        }
+    }
+}
+
+impl From<Tensor> for IrValue {
+    fn from(value: Tensor) -> Self {
+        IrValue::Tensor(IrTensorValue {
+            id: value.id(),
+            shape: value.shape().clone(),
+            dtype: value.dt(),
+        })
+    }
+}
+
+impl From<f32> for IrValue {
+    fn from(value: f32) -> Self {
+        IrValue::Scalar(IrScalarValue::F32(value))
+    }
+}
+
+impl From<i32> for IrValue {
+    fn from(value: i32) -> Self {
+        IrValue::Scalar(IrScalarValue::I32(value))
+    }
+}
+
+impl From<u32> for IrValue {
+    fn from(value: u32) -> Self {
+        IrValue::Scalar(IrScalarValue::U32(value))
+    }
+}
+
+impl From<usize> for IrValue {
+    fn from(value: usize) -> Self {
+        IrValue::Scalar(IrScalarValue::U32(value as u32))
+    }
+}
+
+impl From<bool> for IrValue {
+    fn from(value: bool) -> Self {
+        IrValue::Scalar(IrScalarValue::Bool(value))
+    }
+}
+
+impl From<String> for IrValue {
+    fn from(value: String) -> Self {
+        IrValue::Scalar(IrScalarValue::String(value))
+    }
+}
+
+impl From<&str> for IrValue {
+    fn from(value: &str) -> Self {
+        IrValue::Scalar(IrScalarValue::String(value.to_string()))
+    }
+}
+
+impl From<Range<usize>> for IrValue {
+    fn from(value: Range<usize>) -> Self {
+        IrValue::Vec(rvec![
+            Box::new(IrValue::Scalar(IrScalarValue::U32(value.start as u32))),
+            Box::new(IrValue::Scalar(IrScalarValue::U32(value.end as u32)))
+        ])
+    }
+}
+
+macro_rules! impl_irvalue_for_rvec {
+    ($t:ty) => {
+        impl From<$t> for IrValue {
+            fn from(value: $t) -> Self {
+                IrValue::Vec(value.into_iter().map(|v| Box::new(v.into())).collect())
+            }
+        }
+    };
+}
+
+impl_irvalue_for_rvec!(RVec<Range<usize>>);
+impl_irvalue_for_rvec!(RVec<Tensor>);
+impl_irvalue_for_rvec!(RVec<usize>);
+impl_irvalue_for_rvec!(Shape);
+
+impl From<DType> for IrValue {
+    fn from(value: DType) -> Self {
+        IrValue::Scalar(IrScalarValue::String(value.to_string()))
+    }
+}
+
+impl From<Ir> for IrValue {
+    fn from(value: Ir) -> Self {
+        IrValue::Ir(value)
+    }
+}
+
+impl<T: IrFields + 'static> From<T> for IrValue {
+    fn from(value: T) -> Self {
+        IrValue::Fields(Box::new(value))
+    }
+}
+
+pub struct ComputeCompileKey<'a> {
+    pub dst: &'a Tensor,
+    pub workload: Workload,
+    pub key: KernelKey,
+    pub can_inplace: bool,
+    pub offset: u64,
+}
+
+pub struct CopyCompileKey<'a> {
+    pub src: &'a Tensor,
+    pub dst: &'a Tensor,
+}
+
+pub enum GpuCompileKey<'a> {
+    Compute(ComputeCompileKey<'a>),
+    Copy(CopyCompileKey<'a>),
+}
+
+impl GpuCompileKey<'_> {
+    pub fn can_inplace(&self) -> bool {
+        match self {
+            GpuCompileKey::Compute(compute_key) => compute_key.can_inplace,
+            GpuCompileKey::Copy(_) => false,
+        }
+    }
+}
+
 /// # Operation
 ///
 /// Operation should be implemented for all types that will be a node on the high-level CFG.
 ///
 /// Hardware invariant functions.
-pub trait Operation: OpGuards + Debug + 'static {
+pub trait Operation: OpGuards + IrFields + Debug + 'static {
     /// # Operation Name
     fn name(&self) -> &'static str;
 
@@ -332,6 +683,13 @@ pub trait Operation: OpGuards + Debug + 'static {
     /// Determine if the operation can be performed in-place.
     fn supports_inplace(&self) -> bool {
         false
+    }
+
+    /// Corresponding IR description of the operation.
+    fn ir(&self) -> Ir {
+        let mut ir = Ir::new(self.name());
+        self.ir_fields(&mut ir);
+        ir
     }
 }
 

--- a/crates/ratchet-core/src/op.rs
+++ b/crates/ratchet-core/src/op.rs
@@ -83,7 +83,7 @@ impl LazyOp {
             LazyOp::Cache(c) => c.name(),
             LazyOp::View(v) => v.name(),
             LazyOp::Const => "Const",
-            LazyOp::Detach(_) => "Detach",
+            LazyOp::Detach(d) => Box::leak(format!("Detach<{}>", d.name()).into_boxed_str()),
         }
     }
 

--- a/crates/ratchet-core/src/ops/affine.rs
+++ b/crates/ratchet-core/src/ops/affine.rs
@@ -2,7 +2,7 @@ use derive_new::new;
 use encase::ShaderType;
 use half::f16;
 use inline_wgsl::wgsl;
-use ratchet_macros::WgslMetadata;
+use ratchet_macros::{IrFields, WgslMetadata};
 
 use crate::{
     gpu::{dtype::WgslDType, BindGroupLayoutDescriptor},
@@ -11,7 +11,7 @@ use crate::{
     Tensor, Vec2, Vec4, WgslKernelBuilder, WgslPrimitive, WorkgroupSize, Workload,
 };
 
-#[derive(new, Debug, Clone)]
+#[derive(new, Debug, Clone, IrFields)]
 pub struct Affine {
     pub src: Tensor,
     pub mul: f32,

--- a/crates/ratchet-core/src/ops/affine.rs
+++ b/crates/ratchet-core/src/ops/affine.rs
@@ -225,13 +225,12 @@ mod tests {
     use crate::{shape, test_util::run_py_prg, Device, DeviceRequest, Tensor};
 
     fn ground_truth(a: &Tensor, mul: f32, add: f32) -> anyhow::Result<Tensor> {
-        let prg = format!(
-            r#"
+        let prg = r#"
 import torch
 def affine(a, mul, add):
     return (torch.from_numpy(a) * mul + add).numpy()
-"#,
-        );
+"#
+        .to_string();
 
         run_py_prg(prg.to_string(), &[a], &[&mul, &add], a.dt())
     }

--- a/crates/ratchet-core/src/ops/affine.rs
+++ b/crates/ratchet-core/src/ops/affine.rs
@@ -241,7 +241,7 @@ def affine(a, mul, add):
         let ground = ground_truth(&a, mul, add).unwrap();
 
         let a_gpu = a.to(&device).unwrap();
-        let b = a_gpu.affine(mul, add).unwrap().resolve().unwrap();
+        let b = a_gpu.affine(mul, add).unwrap();
 
         let ours = b.to(&Device::CPU).unwrap();
         println!("ours = {:?}", ours);

--- a/crates/ratchet-core/src/ops/arange.rs
+++ b/crates/ratchet-core/src/ops/arange.rs
@@ -1,5 +1,6 @@
 use derive_new::new;
 use inline_wgsl::wgsl;
+use ratchet_macros::IrFields;
 
 use crate::{
     gpu::BindGroupLayoutDescriptor, rvec, shape, wgc, wgs, Array, BindingMode, BuiltIn, DType,
@@ -8,7 +9,7 @@ use crate::{
     WgslKernelBuilder, WgslPrimitive, WorkgroupCount, WorkgroupSize, Workload,
 };
 
-#[derive(new, Debug, Clone)]
+#[derive(new, Debug, Clone, IrFields)]
 pub struct Arange {
     pub start: f32,
     pub end: f32,

--- a/crates/ratchet-core/src/ops/arange.rs
+++ b/crates/ratchet-core/src/ops/arange.rs
@@ -262,8 +262,6 @@ def arange(start, stop, step):
         let a = Tensor::arange_step(start, stop, step, device)
             .unwrap()
             .cast(DType::F32)
-            .unwrap()
-            .resolve_deferred()
             .unwrap();
         let ground = ground_truth(&start, &stop, &step).unwrap();
 

--- a/crates/ratchet-core/src/ops/binary.rs
+++ b/crates/ratchet-core/src/ops/binary.rs
@@ -313,8 +313,7 @@ def {}(a, b):
             BinaryOp::Sub => a.sub(b)?,
             BinaryOp::Mul => a.mul(b)?,
             BinaryOp::Div => a.div(b)?,
-        }
-        .resolve()?;
+        };
 
         let d = c.to(&Device::CPU)?;
         ground.all_close(&d, 1e-4, 1e-4)?;

--- a/crates/ratchet-core/src/ops/binary.rs
+++ b/crates/ratchet-core/src/ops/binary.rs
@@ -2,7 +2,7 @@ use derive_new::new;
 use encase::ShaderType;
 use half::f16;
 use inline_wgsl::wgsl;
-use ratchet_macros::WgslMetadata;
+use ratchet_macros::{IrFields, WgslMetadata};
 
 use crate::{
     gpu::{dtype::WgslDType, BindGroupLayoutDescriptor},
@@ -15,7 +15,7 @@ use crate::{
 use test_strategy::Arbitrary;
 
 #[cfg_attr(test, derive(Arbitrary))]
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Hash, IrFields)]
 pub enum BinaryOp {
     Add,
     Sub,
@@ -43,7 +43,7 @@ impl BinaryOp {
     }
 }
 
-#[derive(new, Debug, Clone)]
+#[derive(new, Debug, Clone, IrFields)]
 pub struct Binary {
     pub lhs: Tensor,
     pub rhs: Tensor,

--- a/crates/ratchet-core/src/ops/cache.rs
+++ b/crates/ratchet-core/src/ops/cache.rs
@@ -3,8 +3,7 @@ use encase::ShaderType;
 use glam::UVec4;
 use half::f16;
 use inline_wgsl::wgsl;
-use ratchet_macros::WgslMetadata;
-use wgpu::BindGroupLayoutEntry;
+use ratchet_macros::{IrFields, WgslMetadata};
 
 use crate::{
     gpu::BindGroupLayoutDescriptor, rvec, Array, BindGroupLayoutEntryDescriptor,
@@ -22,7 +21,7 @@ use crate::{
 /// 1. Cache, large partially filled tensors. E.g [1, 512, 1024], with [1, 5, 1024] filled.
 /// 2. Source, new K or V tensor, e.g [1, 1, 1024]
 /// 3. offset, where to start the write in the cache tensor, e.g [1, 5, 1024], [1, 1, 1024], offset = 5 -> [1, 6, 1024]
-#[derive(new, Debug, Clone)]
+#[derive(new, Debug, Clone, IrFields)]
 pub struct Cache {
     cache: Tensor,
     source: Tensor,

--- a/crates/ratchet-core/src/ops/cache.rs
+++ b/crates/ratchet-core/src/ops/cache.rs
@@ -7,8 +7,8 @@ use ratchet_macros::WgslMetadata;
 use wgpu::BindGroupLayoutEntry;
 
 use crate::{
-    gpu::{BindGroupLayoutDescriptor, BindGroupLayoutEntryExt},
-    rvec, Array, BindingMode, BuiltIn, DType, GPUOperation, Kernel, KernelElement,
+    gpu::BindGroupLayoutDescriptor, rvec, Array, BindGroupLayoutEntryDescriptor,
+    BindGroupLayoutEntryExt, BindingMode, BuiltIn, DType, GPUOperation, Kernel, KernelElement,
     KernelRenderable, KernelSource, OpGuards, Operation, OperationError, RVec, Scalar, Shape,
     StorageView, Strides, Tensor, Vec2, Vec4, WgslKernelBuilder, WgslPrimitive, WorkgroupSize,
     Workload,
@@ -175,9 +175,9 @@ impl Kernel for CacheKernels {
         // Custom layout because of funky mutability requirements
         Ok(BindGroupLayoutDescriptor {
             entries: rvec![
-                BindGroupLayoutEntry::compute_storage_buffer(0, false),
-                BindGroupLayoutEntry::compute_storage_buffer(1, true),
-                BindGroupLayoutEntry::compute_storage_buffer(2, false)
+                BindGroupLayoutEntryDescriptor::compute_storage_buffer(0, false),
+                BindGroupLayoutEntryDescriptor::compute_storage_buffer(1, true),
+                BindGroupLayoutEntryDescriptor::compute_storage_buffer(2, false)
             ],
         })
     }

--- a/crates/ratchet-core/src/ops/cache.rs
+++ b/crates/ratchet-core/src/ops/cache.rs
@@ -273,7 +273,7 @@ mod tests {
         println!("PREVIOUS CACHE\n {:?}\n", dst0.to_ndarray_view::<f32>());
         dst0 = dst0.to(&device)?;
         let dst1 = Tensor::zeros::<f32>(&shape![1, 2, 4, 16], &device);
-        let cur_cache = Tensor::cat(rvec![dst0.clone(), dst1], 2)?.resolve()?;
+        let cur_cache = Tensor::cat(rvec![dst0.clone(), dst1], 2)?;
 
         //This is the k or v vector we write
         let mut src = Tensor::randn::<f32>(0., 1., shape![1, 2, 1, 16], Device::CPU);
@@ -281,12 +281,10 @@ mod tests {
         src = src.to(&device)?;
 
         //The result should be the concatenation of the cache and the source
-        let ground_truth = Tensor::cat(rvec![dst0.clone(), src.clone()], 2)?
-            .resolve()?
-            .to(&Device::CPU)?;
+        let ground_truth = Tensor::cat(rvec![dst0.clone(), src.clone()], 2)?.to(&Device::CPU)?;
 
         let dim = 2;
-        let b = cur_cache.clone().cache(src, dim, populated)?.resolve()?;
+        let b = cur_cache.clone().cache(src, dim, populated)?;
 
         let cur_cache_cpu = cur_cache.to(&Device::CPU)?;
         println!(

--- a/crates/ratchet-core/src/ops/cast.rs
+++ b/crates/ratchet-core/src/ops/cast.rs
@@ -265,7 +265,7 @@ def cast(a):
         let ground = ground_truth(&input, dst_dt)?;
 
         let input = input.to(&device)?;
-        let casted = input.cast(dst_dt)?.resolve()?;
+        let casted = input.cast(dst_dt)?;
 
         let casted = casted.to(&Device::CPU)?;
         match dst_dt {

--- a/crates/ratchet-core/src/ops/cast.rs
+++ b/crates/ratchet-core/src/ops/cast.rs
@@ -2,7 +2,7 @@ use derive_new::new;
 use encase::ShaderType;
 use half::f16;
 use inline_wgsl::wgsl;
-use ratchet_macros::WgslMetadata;
+use ratchet_macros::{IrFields, WgslMetadata};
 
 use crate::{
     gpu::BindGroupLayoutDescriptor, rvec, Array, BindingMode, BuiltIn, DType, GPUOperation, Kernel,
@@ -11,7 +11,7 @@ use crate::{
     WorkgroupSize, Workload,
 };
 
-#[derive(new, Debug, Clone)]
+#[derive(new, Debug, Clone, IrFields)]
 pub struct Cast {
     input: Tensor,
     dst_dt: DType,

--- a/crates/ratchet-core/src/ops/cmp.rs
+++ b/crates/ratchet-core/src/ops/cmp.rs
@@ -2,7 +2,7 @@ use derive_new::new;
 use encase::ShaderType;
 use half::f16;
 use inline_wgsl::wgsl;
-use ratchet_macros::WgslMetadata;
+use ratchet_macros::{IrFields, WgslMetadata};
 
 use crate::{
     gpu::{dtype::WgslDType, BindGroupLayoutDescriptor},
@@ -15,7 +15,7 @@ use crate::{
 use test_strategy::Arbitrary;
 
 #[cfg_attr(test, derive(Arbitrary))]
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Hash, IrFields)]
 pub enum CmpOp {
     Eq,
     Ne,
@@ -49,7 +49,7 @@ impl CmpOp {
     }
 }
 
-#[derive(new, Debug, Clone)]
+#[derive(new, Debug, Clone, IrFields)]
 pub struct Cmp {
     pub lhs: Tensor,
     pub rhs: Tensor,

--- a/crates/ratchet-core/src/ops/cmp.rs
+++ b/crates/ratchet-core/src/ops/cmp.rs
@@ -308,7 +308,7 @@ def {}(a, b):
         let BinaryProblem { op, shape } = prob;
         let a = Tensor::randn::<f32>(0., 1., shape.clone(), cpu_device.clone());
         let b = Tensor::randn::<f32>(0., 1., shape, cpu_device.clone());
-        let ground = ground_truth(&a, &b, &op)?.cast(DType::F32)?.resolve()?;
+        let ground = ground_truth(&a, &b, &op)?.cast(DType::F32)?;
 
         let a_gpu = a.to(&device)?;
         let b_gpu = b.to(&device)?;
@@ -319,10 +319,9 @@ def {}(a, b):
             CmpOp::Ge => a_gpu.ge(b_gpu)?,
             CmpOp::Lt => a_gpu.le(b_gpu)?,
             CmpOp::Gt => a_gpu.gt(b_gpu)?,
-        }
-        .resolve()?;
+        };
 
-        let d_gpu = c_gpu.to(&Device::CPU)?.cast(DType::F32)?.resolve()?;
+        let d_gpu = c_gpu.to(&Device::CPU)?.cast(DType::F32)?;
         ground.all_close(&d_gpu, 1e-4, 1e-4)?;
         Ok(())
     }

--- a/crates/ratchet-core/src/ops/concat.rs
+++ b/crates/ratchet-core/src/ops/concat.rs
@@ -320,7 +320,7 @@ def permute(*tensors):
             t.to(&device)?;
         }
         let t_rvec = RVec::from(tensors);
-        let ours = Tensor::cat(t_rvec, dim)?.resolve()?;
+        let ours = Tensor::cat(t_rvec, dim)?;
         let result = ours.to(&Device::CPU)?;
         println!("Ground: {:?}\n", ground);
         println!("Ours: {:?}", result);

--- a/crates/ratchet-core/src/ops/concat.rs
+++ b/crates/ratchet-core/src/ops/concat.rs
@@ -2,6 +2,7 @@ use derive_new::new;
 use glam::UVec4;
 use half::f16;
 use inline_wgsl::wgsl;
+use ratchet_macros::IrFields;
 
 use crate::{
     gpu::BindGroupLayoutDescriptor, rvec, Array, BindingMode, BuiltIn, DType, DynKernelMetadata,
@@ -10,7 +11,7 @@ use crate::{
     WgslKernelBuilder, WgslPrimitive, WorkgroupSize, Workload,
 };
 
-#[derive(new, Debug, Clone)]
+#[derive(new, Debug, Clone, IrFields)]
 pub struct Concat {
     pub inputs: RVec<Tensor>,
     pub dim: usize,

--- a/crates/ratchet-core/src/ops/concat.rs
+++ b/crates/ratchet-core/src/ops/concat.rs
@@ -17,6 +17,8 @@ pub struct Concat {
     pub dim: usize,
 }
 
+const MAX_INPUTS: usize = 8;
+
 impl Concat {
     pub fn inputs(&self) -> &[Tensor] {
         &self.inputs
@@ -132,7 +134,7 @@ impl Operation for Concat {
 impl OpGuards for Concat {
     fn check_shapes(&self) {
         assert!(self.inputs.len() > 1);
-        assert!(self.inputs.len() <= 8); //We only generate kernels for up to 8 inputs
+        assert!(self.inputs.len() <= MAX_INPUTS); //We only generate kernels for up to 8 inputs
         let first = &self.inputs[0];
         assert!(self
             .inputs

--- a/crates/ratchet-core/src/ops/conv.rs
+++ b/crates/ratchet-core/src/ops/conv.rs
@@ -332,11 +332,7 @@ def conv(input, filters, bias, stride, padding):
         let input = input.to(device).unwrap();
         let weight = weight.to(device).unwrap();
         let bias = bias.to(device).unwrap();
-        let ours = input
-            .conv1d(weight, Some(bias), stride, 1)
-            .unwrap()
-            .resolve()
-            .unwrap();
+        let ours = input.conv1d(weight, Some(bias), stride, 1).unwrap();
         let ours = ours.to(&Device::CPU).unwrap();
 
         println!("ours = {:?}", ours);

--- a/crates/ratchet-core/src/ops/conv.rs
+++ b/crates/ratchet-core/src/ops/conv.rs
@@ -2,7 +2,7 @@
 use derive_new::new;
 use encase::ShaderType;
 use half::f16;
-use ratchet_macros::WgslMetadata;
+use ratchet_macros::{IrFields, WgslMetadata};
 
 use crate::{
     gpu::{dtype::WgslDType, BindGroupLayoutDescriptor, WorkgroupCount},
@@ -12,7 +12,7 @@ use crate::{
 };
 use inline_wgsl::wgsl;
 
-#[derive(new, Debug, Clone)]
+#[derive(new, Debug, Clone, IrFields)]
 pub struct Conv {
     pub input: Tensor,
     pub weight: Tensor,

--- a/crates/ratchet-core/src/ops/fill_constant.rs
+++ b/crates/ratchet-core/src/ops/fill_constant.rs
@@ -2,7 +2,7 @@ use derive_new::new;
 use encase::ShaderType;
 use half::f16;
 use inline_wgsl::wgsl;
-use ratchet_macros::WgslMetadata;
+use ratchet_macros::{IrFields, WgslMetadata};
 
 use crate::{
     gpu::{dtype::WgslDType, BindGroupLayoutDescriptor},
@@ -12,9 +12,9 @@ use crate::{
     Workload,
 };
 
-#[derive(new, Debug, Clone)]
+#[derive(new, Debug, Clone, IrFields)]
 pub struct FillConstant {
-    pub shape: Vec<usize>,
+    pub shape: Shape,
     pub value: f32,
 }
 
@@ -29,7 +29,7 @@ impl Operation for FillConstant {
         "FillConstant"
     }
     fn compute_view(&self) -> Result<StorageView, OperationError> {
-        let shape: Shape = self.shape.clone().into();
+        let shape: Shape = self.shape.clone();
         let strides = Strides::from(&shape);
         Ok(StorageView::new(shape, DType::F32, strides))
     }
@@ -148,7 +148,7 @@ impl Kernel for FillConstantKernels {
     fn metadata(&self, _: &Tensor, _: &KernelElement) -> Result<Self::Metadata, OperationError> {
         let FillConstantKernels::Standard(inner) = self;
         Ok(FillConstantMeta {
-            numel: Shape::from(inner.shape.clone()).numel() as u32,
+            numel: inner.shape.clone().numel() as u32,
             value: inner.value,
         })
     }

--- a/crates/ratchet-core/src/ops/fill_constant.rs
+++ b/crates/ratchet-core/src/ops/fill_constant.rs
@@ -216,9 +216,7 @@ def fill_constant(shape, value):
     fn run_fill_constant_trial(problem: FillConstantProblem, device: Device) {
         let FillConstantProblem { B, M, N, value } = problem;
 
-        let a = Tensor::full(&shape![B, M, N], value, &device)
-            .resolve_deferred()
-            .unwrap();
+        let a = Tensor::full(&shape![B, M, N], value, &device);
         let ground = ground_truth(&[B, M, N], value).unwrap();
 
         let a_gpu = a.to(&device).unwrap();

--- a/crates/ratchet-core/src/ops/fill_randn.rs
+++ b/crates/ratchet-core/src/ops/fill_randn.rs
@@ -233,16 +233,12 @@ def check_normal(output):
         let FillRandnProblem { B, M, N } = problem;
 
         let a = Tensor::randn::<f32>(0f32, 1f32, shape![B, M, N], device.clone())
-            .resolve_deferred()
-            .unwrap()
             .to(&Device::CPU)
             .unwrap();
 
         let params = normal_parameters(&a)
             .unwrap()
             .to(&device)
-            .unwrap()
-            .resolve_deferred()
             .unwrap()
             .to(&Device::CPU)
             .unwrap()

--- a/crates/ratchet-core/src/ops/fill_randn.rs
+++ b/crates/ratchet-core/src/ops/fill_randn.rs
@@ -2,7 +2,7 @@ use derive_new::new;
 use encase::ShaderType;
 use half::f16;
 use inline_wgsl::wgsl;
-use ratchet_macros::WgslMetadata;
+use ratchet_macros::{IrFields, WgslMetadata};
 
 use crate::{
     gpu::BindGroupLayoutDescriptor, rvec, Array, BindingMode, BuiltIn, DType, GPUOperation, Kernel,
@@ -11,9 +11,9 @@ use crate::{
     WorkgroupSize, Workload,
 };
 
-#[derive(new, Debug, Clone)]
+#[derive(new, Debug, Clone, IrFields)]
 pub struct FillRandn {
-    pub shape: Vec<usize>,
+    pub shape: Shape,
     pub mean: f32,
     pub std: f32,
     pub seed: Option<u32>,
@@ -33,7 +33,7 @@ impl Operation for FillRandn {
     }
 
     fn compute_view(&self) -> Result<StorageView, OperationError> {
-        let shape: Shape = self.shape.clone().into();
+        let shape: Shape = self.shape.clone();
         let strides = Strides::from(&shape);
         Ok(StorageView::new(shape, crate::DType::F32, strides))
     }
@@ -167,7 +167,7 @@ impl Kernel for FillRandnKernels {
     fn metadata(&self, _: &Tensor, _: &KernelElement) -> Result<Self::Metadata, OperationError> {
         let FillRandnKernels::Standard(inner) = self;
         Ok(FillRandnMeta {
-            numel: Shape::from(inner.shape.clone()).numel() as u32,
+            numel: inner.shape.clone().numel() as u32,
             mean: inner.mean,
             stddev: inner.std,
             seed: inner.seed.unwrap_or(0),

--- a/crates/ratchet-core/src/ops/gather.rs
+++ b/crates/ratchet-core/src/ops/gather.rs
@@ -8,9 +8,9 @@ use derive_new::new;
 use encase::ShaderType;
 use half::f16;
 use inline_wgsl::wgsl;
-use ratchet_macros::WgslMetadata;
+use ratchet_macros::{IrFields, WgslMetadata};
 
-#[derive(new, Debug, Clone)]
+#[derive(new, Debug, Clone, IrFields)]
 pub struct Gather {
     pub src: Tensor,
     pub ids: Tensor,

--- a/crates/ratchet-core/src/ops/gather.rs
+++ b/crates/ratchet-core/src/ops/gather.rs
@@ -247,7 +247,7 @@ def gather(src, ids, dim):
         let src_gpu = src.to(&device).unwrap();
         let ids_gpu = ids.to(&device).unwrap();
 
-        let result = src_gpu.gather(ids_gpu, dim).unwrap().resolve_debug().unwrap();
+        let result = src_gpu.gather(ids_gpu, dim).unwrap();
 
         let ours = result.to(&Device::CPU).unwrap();
         log::debug!("src = {:?}", src);
@@ -323,11 +323,11 @@ def gather_backward(src, ids):
         let result_gpu = src_var
             .as_tensor()
             .clone()
-            .gather(ids_gpu, dim)?
-            .resolve_deferred()?;
+            .gather(ids_gpu, dim)?;
 
-        let mut grads = result_gpu.backward()?;
-        grads.resolve(device.try_gpu()?)?;
+        let grads = result_gpu.backward()?;
+        device.try_gpu()?.mark_step()?;
+
         let src_grad = grads.get(src_var.as_tensor()).unwrap().clone();
 
         let ours = src_grad.to(&Device::CPU)?;

--- a/crates/ratchet-core/src/ops/gather.rs
+++ b/crates/ratchet-core/src/ops/gather.rs
@@ -271,6 +271,7 @@ def gather(src, ids, dim):
 
     #[proptest(cases = 8)]
     fn test_gather(prob: GatherProblem) {
+        let _ = env_logger::builder().is_test(true).try_init();
         let GatherProblem { B, M, N, dim } = prob;
         log::info!("B = {}, M = {}, N = {}, dim = {}", B, M, N, dim);
         let device = Device::request_device(DeviceRequest::GPU).unwrap();
@@ -344,6 +345,7 @@ def gather_backward(src, ids):
 
     #[proptest(cases = 8)]
     fn test_gather_backward(prob: GatherBackwardProblem) {
+        let _ = env_logger::builder().is_test(true).try_init();
         let GatherBackwardProblem { B, M, N, dim } = prob;
         println!("B = {}, M = {}, N = {}, dim = {}", B, M, N, dim);
         run_gather_backward_trial(prob).unwrap();

--- a/crates/ratchet-core/src/ops/index_add.rs
+++ b/crates/ratchet-core/src/ops/index_add.rs
@@ -8,9 +8,9 @@ use derive_new::new;
 use encase::ShaderType;
 use half::f16;
 use inline_wgsl::wgsl;
-use ratchet_macros::WgslMetadata;
+use ratchet_macros::{IrFields, WgslMetadata};
 
-#[derive(new, Debug, Clone)]
+#[derive(new, Debug, Clone, IrFields)]
 pub struct IndexAdd {
     pub dst: Tensor,
     pub src: Tensor,

--- a/crates/ratchet-core/src/ops/index_add.rs
+++ b/crates/ratchet-core/src/ops/index_add.rs
@@ -263,14 +263,10 @@ def index_add(input, source, indices):
         source_shape[0] = indices.shape()[0];
 
         let input = Tensor::randn::<f32>(0., 1., input_shape.clone(), device.clone())
-            .resolve()
-            .unwrap()
             .to(&Device::CPU)
             .unwrap();
 
         let source = Tensor::randn::<f32>(0., 1., source_shape.clone(), device.clone())
-            .resolve()
-            .unwrap()
             .to(&Device::CPU)
             .unwrap();
 
@@ -292,11 +288,7 @@ def index_add(input, source, indices):
         let indices = indices.to(&device).unwrap();
         let source = source.to(&device).unwrap();
 
-        let result = input
-            .index_add(indices.clone(), source.clone(), 0)
-            .unwrap()
-            .resolve()
-            .unwrap();
+        let result = input.index_add(indices.clone(), source.clone(), 0).unwrap();
         let x = result.to(&Device::CPU).unwrap();
 
         log::debug!("x = {:?}", x);

--- a/crates/ratchet-core/src/ops/index_write.rs
+++ b/crates/ratchet-core/src/ops/index_write.rs
@@ -213,11 +213,7 @@ mod tests {
         let dst = Tensor::from_data(vec![1., 2., 3., 4., 5., 6.], shape![3, 2], device.clone());
         let src = Tensor::from_data(vec![7., 8.], shape![1, 2], device.clone());
         let write_start = rvec![2, 0];
-        let b = dst
-            .index_write(src, write_start)
-            .unwrap()
-            .resolve()
-            .unwrap();
+        let b = dst.index_write(src, write_start).unwrap();
 
         let result = b.to(&Device::CPU).unwrap();
 

--- a/crates/ratchet-core/src/ops/index_write.rs
+++ b/crates/ratchet-core/src/ops/index_write.rs
@@ -2,7 +2,7 @@ use derive_new::new;
 use encase::ShaderType;
 use half::f16;
 use inline_wgsl::wgsl;
-use ratchet_macros::WgslMetadata;
+use ratchet_macros::{IrFields, WgslMetadata};
 
 use crate::{
     gpu::BindGroupLayoutDescriptor, rvec, Array, BindingMode, BuiltIn, DType, GPUOperation, Kernel,
@@ -11,7 +11,7 @@ use crate::{
     WorkgroupSize, Workload,
 };
 
-#[derive(new, Debug, Clone)]
+#[derive(new, Debug, Clone, IrFields)]
 pub struct IndexWrite {
     dst: Tensor,
     src: Tensor,

--- a/crates/ratchet-core/src/ops/matmul/mod.rs
+++ b/crates/ratchet-core/src/ops/matmul/mod.rs
@@ -942,9 +942,7 @@ def matmul(a, b{}):
         let a_gpu = a.to(device)?;
         let b_gpu = b.to(device)?;
         let bias_gpu = bias.as_ref().map(|b| b.to(device)).transpose()?;
-        let c_gpu = a_gpu
-            .gemm(b_gpu, bias_gpu, trans_lhs, trans_rhs, trans_dst)?
-            .resolve()?;
+        let c_gpu = a_gpu.gemm(b_gpu, bias_gpu, trans_lhs, trans_rhs, trans_dst)?;
 
         let d_gpu = c_gpu.to(&Device::CPU)?;
         println!("RATCHET SGEMM\n{:?}\n", d_gpu);
@@ -965,7 +963,7 @@ def matmul(a, b{}):
         let aq = quantize::<Q8_0F>(&a);
         let a_gpu = aq.to(&device)?;
         let b_gpu = b.to(&device)?;
-        let c_gpu = a_gpu.matmul(b_gpu, false, false)?.resolve()?;
+        let c_gpu = a_gpu.matmul(b_gpu, false, false)?;
         let ours = c_gpu.to(&Device::CPU)?;
 
         println!("RATCHET QUANT\n{:?}\n", ours);
@@ -1007,9 +1005,7 @@ def matmul(a, b{}):
 
         let b_gpu = b.to(&device)?;
         let bias_gpu = bias.as_ref().map(|b| b.to(&device)).transpose()?;
-        let c_gpu = a_gpu
-            .gemm(b_gpu, bias_gpu, TRANS_LHS, TRANS_RHS, TRANS_DST)?
-            .resolve()?;
+        let c_gpu = a_gpu.gemm(b_gpu, bias_gpu, TRANS_LHS, TRANS_RHS, TRANS_DST)?;
         let ours = c_gpu.to(&Device::CPU)?;
 
         println!("RATCHET\n{:?}\n", ours.to_ndarray_view::<f32>());
@@ -1044,9 +1040,7 @@ def matmul(a, b{}):
         };
 
         let b_gpu = b.to(&device)?;
-        let c_gpu = a_gpu
-            .gemm(b_gpu, None, TRANS_LHS, TRANS_RHS, TRANS_DST)?
-            .resolve()?;
+        let c_gpu = a_gpu.gemm(b_gpu, None, TRANS_LHS, TRANS_RHS, TRANS_DST)?;
         let ours = c_gpu.to(&Device::CPU)?;
 
         println!("RATCHET\n{:?}\n", ours.to_ndarray_view::<f32>());

--- a/crates/ratchet-core/src/ops/matmul/mod.rs
+++ b/crates/ratchet-core/src/ops/matmul/mod.rs
@@ -5,6 +5,7 @@ mod workgroup_gemv;
 
 pub use gemm::*;
 pub use quantized::*;
+use ratchet_macros::IrFields;
 pub use subgroup_gemv::*;
 pub use workgroup_gemv::*;
 
@@ -378,7 +379,7 @@ impl MatmulSpec {
     }
 }
 
-#[derive(derive_new::new, Debug, Clone)]
+#[derive(derive_new::new, Debug, Clone, IrFields)]
 pub struct Matmul {
     pub(crate) lhs: Tensor,
     pub(crate) rhs: Tensor,

--- a/crates/ratchet-core/src/ops/norm/groupnorm.rs
+++ b/crates/ratchet-core/src/ops/norm/groupnorm.rs
@@ -56,9 +56,7 @@ def manual_group_norm(input, scale, bias, num_groups):
         let scale_gpu = scale.to(device)?;
         let bias_gpu = bias.map(|b| b.to(device)).transpose()?;
 
-        let result = input_gpu
-            .group_norm(num_groups, scale_gpu, bias_gpu, 1e-5)?
-            .resolve()?;
+        let result = input_gpu.group_norm(num_groups, scale_gpu, bias_gpu, 1e-5)?;
 
         let ours = result.to(&Device::CPU)?;
 

--- a/crates/ratchet-core/src/ops/norm/groupnorm.rs
+++ b/crates/ratchet-core/src/ops/norm/groupnorm.rs
@@ -1,8 +1,9 @@
 use derive_new::new;
+use ratchet_macros::IrFields;
 
 use super::*;
 
-#[derive(new, Debug, Clone)]
+#[derive(new, Debug, Clone, IrFields)]
 pub struct GroupNorm {
     pub norm: Norm,
     pub num_groups: usize,

--- a/crates/ratchet-core/src/ops/norm/groupnorm.rs
+++ b/crates/ratchet-core/src/ops/norm/groupnorm.rs
@@ -67,7 +67,7 @@ def manual_group_norm(input, scale, bias, num_groups):
 
     #[derive(Arbitrary, Debug)]
     struct GroupNormProblem {
-        #[map(|num_groups: u32| #C/2 )]
+        #[map(|_num_groups: u32| #C/2 )]
         num_groups: usize,
         #[strategy(1..=1usize)]
         B: usize,

--- a/crates/ratchet-core/src/ops/norm/mod.rs
+++ b/crates/ratchet-core/src/ops/norm/mod.rs
@@ -13,8 +13,9 @@ use crate::{
 };
 use derive_new::new;
 use inline_wgsl::wgsl;
+use ratchet_macros::IrFields;
 
-#[derive(new, Debug, Clone)]
+#[derive(new, Debug, Clone, IrFields)]
 pub struct Norm {
     pub(crate) input: Tensor,
     pub(crate) scale: Tensor,
@@ -84,7 +85,7 @@ impl Operation for NormOp {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, IrFields)]
 pub enum NormOp {
     LayerNorm(Norm),
     RMSNorm(Norm),

--- a/crates/ratchet-core/src/ops/norm/mod.rs
+++ b/crates/ratchet-core/src/ops/norm/mod.rs
@@ -461,8 +461,8 @@ def manual_rms_norm(input, scale):
         let bias_gpu = bias.map(|b| b.to(device)).transpose()?;
 
         let result = match var {
-            NormVariant::LayerNorm => input_gpu.layer_norm(scale_gpu, bias_gpu, 1e-5)?.resolve()?,
-            NormVariant::RMSNorm => input_gpu.rms_norm(scale_gpu, 1e-5)?.resolve()?,
+            NormVariant::LayerNorm => input_gpu.layer_norm(scale_gpu, bias_gpu, 1e-5)?,
+            NormVariant::RMSNorm => input_gpu.rms_norm(scale_gpu, 1e-5)?,
         };
 
         let ours = result.to(&Device::CPU)?;

--- a/crates/ratchet-core/src/ops/powf.rs
+++ b/crates/ratchet-core/src/ops/powf.rs
@@ -231,7 +231,9 @@ mod tests {
         let func_prg = r#"
 import torch
 def powf(a, e):
-    return torch.pow(torch.from_numpy(a), e).numpy()
+    a_tensor = torch.from_numpy(a)
+    sign = torch.sign(a_tensor)
+    return (torch.pow(torch.abs(a_tensor), e) * sign).numpy()
 "#
         .to_string();
 
@@ -246,10 +248,11 @@ def powf(a, e):
         let ground = ground_truth(&a, e).unwrap();
 
         let a_gpu = a.to(&device).unwrap();
-        let b = a_gpu.powf(2.).unwrap();
+        let b = a_gpu.powf(e).unwrap();
 
         let ours = b.to(&Device::CPU).unwrap();
-        ground.all_close(&ours, 1e-6, 1e-6).unwrap();
+
+        ground.all_close(&ours, 1e-5, 1e-5).unwrap();
     }
 
     #[derive(Arbitrary, Debug)]
@@ -260,7 +263,7 @@ def powf(a, e):
         M: usize,
         #[strategy(1..=128usize)]
         N: usize,
-        #[map(|x: f32| x + 1.)]
+        #[strategy(-10.0f32..=10.0f32)]
         e: f32,
     }
 

--- a/crates/ratchet-core/src/ops/powf.rs
+++ b/crates/ratchet-core/src/ops/powf.rs
@@ -2,7 +2,7 @@ use derive_new::new;
 use encase::ShaderType;
 use half::f16;
 use inline_wgsl::wgsl;
-use ratchet_macros::WgslMetadata;
+use ratchet_macros::{IrFields, WgslMetadata};
 
 use crate::{
     gpu::{dtype::WgslDType, BindGroupLayoutDescriptor},
@@ -11,7 +11,7 @@ use crate::{
     Tensor, Vec2, Vec4, WgslKernelBuilder, WgslPrimitive, WorkgroupSize, Workload,
 };
 
-#[derive(new, Debug, Clone)]
+#[derive(new, Debug, Clone, IrFields)]
 pub struct Powf {
     pub src: Tensor,
     pub e: f32,

--- a/crates/ratchet-core/src/ops/powf.rs
+++ b/crates/ratchet-core/src/ops/powf.rs
@@ -246,7 +246,7 @@ def powf(a, e):
         let ground = ground_truth(&a, e).unwrap();
 
         let a_gpu = a.to(&device).unwrap();
-        let b = a_gpu.powf(2.).unwrap().resolve().unwrap();
+        let b = a_gpu.powf(2.).unwrap();
 
         let ours = b.to(&Device::CPU).unwrap();
         ground.all_close(&ours, 1e-6, 1e-6).unwrap();

--- a/crates/ratchet-core/src/ops/reindex/broadcast.rs
+++ b/crates/ratchet-core/src/ops/reindex/broadcast.rs
@@ -3,6 +3,7 @@ use encase::ShaderType;
 use ratchet_macros::WgslMetadata;
 
 use crate::{rvec, OpGuards, Operation, OperationError, RVec, Shape, StorageView, Strides, Tensor};
+use ratchet_macros::IrFields;
 
 #[derive(Debug, WgslMetadata, ShaderType, derive_new::new)]
 pub struct BroadcastMeta {
@@ -14,7 +15,7 @@ pub struct BroadcastMeta {
     dst_numel: u32,
 }
 
-#[derive(new, Debug, Clone)]
+#[derive(new, Debug, Clone, IrFields)]
 pub struct Broadcast {
     pub src: Tensor,
     to: Shape,

--- a/crates/ratchet-core/src/ops/reindex/broadcast.rs
+++ b/crates/ratchet-core/src/ops/reindex/broadcast.rs
@@ -151,7 +151,7 @@ def slice(a):
 
         let a_gpu = a.to(&device)?;
         let ground = ground_truth(&a, &op.to.as_torch())?;
-        let ours = a_gpu.broadcast_to(op.to.clone())?.resolve()?;
+        let ours = a_gpu.broadcast_to(op.to.clone())?;
         let d_gpu = ours.to(&Device::CPU)?;
         ground.all_close(&d_gpu, 1e-5, 1e-5)?;
         Ok(())

--- a/crates/ratchet-core/src/ops/reindex/mod.rs
+++ b/crates/ratchet-core/src/ops/reindex/mod.rs
@@ -7,6 +7,7 @@ use broadcast::BroadcastMeta;
 use half::f16;
 pub use permute::Permute;
 use permute::PermuteMeta;
+use ratchet_macros::IrFields;
 pub use slice::Slice;
 
 use derive_new::new;
@@ -21,7 +22,7 @@ use crate::{
 };
 use glam::UVec4;
 
-#[derive(new, Debug, Clone)]
+#[derive(new, Debug, Clone, IrFields)]
 pub enum Reindex {
     Permute(Permute),
     Slice(Slice),

--- a/crates/ratchet-core/src/ops/reindex/permute.rs
+++ b/crates/ratchet-core/src/ops/reindex/permute.rs
@@ -2,7 +2,7 @@ use std::collections::HashSet;
 
 use derive_new::new;
 use encase::ShaderType;
-use ratchet_macros::WgslMetadata;
+use ratchet_macros::{IrFields, WgslMetadata};
 
 use crate::{
     rvec, InvariantError, OpGuards, Operation, OperationError, RVec, StorageView, Strides, Tensor,
@@ -19,14 +19,14 @@ pub struct PermuteMeta {
     perm: glam::UVec4,
 }
 
-#[derive(new, Debug, Clone)]
+#[derive(new, Debug, Clone, IrFields)]
 pub struct Permute {
     pub src: Tensor,
-    pub dims: Vec<usize>,
+    pub dims: RVec<usize>,
 }
 
 impl Permute {
-    pub fn promote(&self) -> Vec<usize> {
+    pub fn promote(&self) -> RVec<usize> {
         let pad_len = 4 - self.dims.len();
 
         let mut perm = self.dims.clone();
@@ -87,7 +87,10 @@ mod tests {
             Shape::arbitrary_with(ranges)
                 .prop_flat_map(|shape| (Just(shape.clone()), Just(vec![0, 1, 2, 3]).prop_shuffle()))
                 .prop_map(|(shape, perm)| {
-                    Permute::new(Tensor::randn::<f32>(0., 1., shape, Device::CPU), perm)
+                    Permute::new(
+                        Tensor::randn::<f32>(0., 1., shape, Device::CPU),
+                        perm.into(),
+                    )
                 })
                 .boxed()
         }

--- a/crates/ratchet-core/src/ops/reindex/permute.rs
+++ b/crates/ratchet-core/src/ops/reindex/permute.rs
@@ -120,7 +120,7 @@ def permute(a):
 
         let a_gpu = a.to(&device)?;
         let ground = ground_truth(&a, format!("{:?}", op.dims).as_str())?;
-        let ours = a_gpu.permute(&op.dims)?.resolve()?;
+        let ours = a_gpu.permute(&op.dims)?;
         let d_gpu = ours.to(&Device::CPU)?;
         ground.all_close(&d_gpu, 1e-5, 1e-5)?;
         Ok(())

--- a/crates/ratchet-core/src/ops/reindex/slice.rs
+++ b/crates/ratchet-core/src/ops/reindex/slice.rs
@@ -1,5 +1,5 @@
 use encase::ShaderType;
-use ratchet_macros::WgslMetadata;
+use ratchet_macros::{IrFields, WgslMetadata};
 
 use crate::{prelude::*, OpGuards, OperationError, StorageView, Strides};
 use crate::{Operation, RVec};
@@ -19,7 +19,7 @@ pub struct SliceMeta {
 /// # Slice
 ///
 /// This is a temporary, user hostile implementation.
-#[derive(derive_new::new, Debug, Clone)]
+#[derive(derive_new::new, Debug, Clone, IrFields)]
 pub struct Slice {
     pub src: Tensor,
     pub indices: RVec<Range<usize>>,

--- a/crates/ratchet-core/src/ops/reindex/slice.rs
+++ b/crates/ratchet-core/src/ops/reindex/slice.rs
@@ -165,7 +165,7 @@ def slice(a):
 
         let a_gpu = a.to(&device)?;
         let ground = ground_truth(&a, &op.as_torch())?;
-        let ours = a_gpu.slice(&op.indices)?.resolve()?;
+        let ours = a_gpu.slice(&op.indices)?;
         let d_gpu = ours.to(&Device::CPU)?;
         ground.all_close(&d_gpu, 1e-5, 1e-5)?;
         Ok(())

--- a/crates/ratchet-core/src/ops/rope.rs
+++ b/crates/ratchet-core/src/ops/rope.rs
@@ -1,7 +1,7 @@
 use derive_new::new;
 use encase::ShaderType;
 use half::f16;
-use ratchet_macros::WgslMetadata;
+use ratchet_macros::{IrFields, WgslMetadata};
 
 use crate::gpu::dtype::WgslDType;
 use crate::{
@@ -13,7 +13,7 @@ use crate::{
 use crate::{GPUOperation, Kernel, KernelRenderable};
 use inline_wgsl::wgsl;
 
-#[derive(new, Debug, Clone)]
+#[derive(new, Debug, Clone, IrFields)]
 pub struct RoPE {
     input: Tensor,
     dim: usize,

--- a/crates/ratchet-core/src/ops/rope.rs
+++ b/crates/ratchet-core/src/ops/rope.rs
@@ -304,7 +304,7 @@ def mlx_rope(input, dim, offset):
         let ground = ground_truth(&a, dim, offset).unwrap();
 
         let a = a.to(&device).unwrap();
-        let b = a.rope(dim, 10000.0, offset).unwrap().resolve().unwrap();
+        let b = a.rope(dim, 10000.0, offset).unwrap();
 
         let ours = b.to(&Device::CPU).unwrap();
         //println!("ours = \n{:#?}\n", ours.to_ndarray_view::<f32>());

--- a/crates/ratchet-core/src/ops/scatter_add.rs
+++ b/crates/ratchet-core/src/ops/scatter_add.rs
@@ -262,8 +262,6 @@ def scatter_add(dst, src, ids):
 
         let result = dst_gpu
             .scatter_add(ids_gpu.clone(), src_gpu.clone(), dim)
-            .unwrap()
-            .resolve()
             .unwrap();
 
         let ours = result.to(&Device::CPU).unwrap();

--- a/crates/ratchet-core/src/ops/scatter_add.rs
+++ b/crates/ratchet-core/src/ops/scatter_add.rs
@@ -2,7 +2,7 @@ use derive_new::new;
 use encase::ShaderType;
 use half::f16;
 use inline_wgsl::wgsl;
-use ratchet_macros::WgslMetadata;
+use ratchet_macros::{IrFields, WgslMetadata};
 
 use crate::{
     gpu::BindGroupLayoutDescriptor, rvec, Array, BindingMode, BuiltIn, DType, GPUOperation, Kernel,
@@ -11,7 +11,7 @@ use crate::{
     Workload,
 };
 
-#[derive(new, Debug, Clone)]
+#[derive(new, Debug, Clone, IrFields)]
 pub struct ScatterAdd {
     pub dst: Tensor,
     pub src: Tensor,

--- a/crates/ratchet-core/src/ops/select.rs
+++ b/crates/ratchet-core/src/ops/select.rs
@@ -340,7 +340,7 @@ def index_select(input, indices):
         let input = input.to(&device).unwrap();
         let indices = indices.to(&device).unwrap();
 
-        let result = input.index_select(indices, 0).unwrap().resolve().unwrap();
+        let result = input.index_select(indices, 0).unwrap();
         let x = result.to(&Device::CPU).unwrap();
         println!("X: {:?}", x);
         println!("Ground Truth: {:?}", ground_truth);

--- a/crates/ratchet-core/src/ops/select.rs
+++ b/crates/ratchet-core/src/ops/select.rs
@@ -1,7 +1,7 @@
 use derive_new::new;
 use encase::ShaderType;
 use half::f16;
-use ratchet_macros::WgslMetadata;
+use ratchet_macros::{IrFields, WgslMetadata};
 
 use crate::{
     gpu::{BindGroupLayoutDescriptor, WorkgroupCount},
@@ -11,7 +11,7 @@ use crate::{
 };
 use inline_wgsl::wgsl;
 
-#[derive(new, Debug, Clone)]
+#[derive(new, Debug, Clone, IrFields)]
 pub struct IndexSelect {
     pub src: Tensor,
     pub indices: Tensor,

--- a/crates/ratchet-core/src/ops/softmax.rs
+++ b/crates/ratchet-core/src/ops/softmax.rs
@@ -329,7 +329,7 @@ def softmax(a):
         let ground = ground_truth(&a).unwrap();
 
         let a_gpu = a.to(&device).unwrap();
-        let b = a_gpu.softmax(2).unwrap().resolve().unwrap();
+        let b = a_gpu.softmax(2).unwrap();
 
         let ours = b.to(&Device::CPU).unwrap();
         ground.all_close(&ours, 1e-6, 1e-6).unwrap();

--- a/crates/ratchet-core/src/ops/softmax.rs
+++ b/crates/ratchet-core/src/ops/softmax.rs
@@ -2,7 +2,7 @@ use derive_new::new;
 use encase::ShaderType;
 use half::f16;
 use inline_wgsl::wgsl;
-use ratchet_macros::WgslMetadata;
+use ratchet_macros::{IrFields, WgslMetadata};
 
 use crate::{
     gpu::{dtype::WgslDType, BindGroupLayoutDescriptor},
@@ -11,7 +11,7 @@ use crate::{
     Tensor, Vec2, Vec4, WgslKernelBuilder, WgslPrimitive, WorkgroupSize, Workload,
 };
 
-#[derive(new, Debug, Clone)]
+#[derive(new, Debug, Clone, IrFields)]
 pub struct Softmax {
     pub(crate) input: Tensor,
     pub(crate) dim: usize,

--- a/crates/ratchet-core/src/ops/trilu.rs
+++ b/crates/ratchet-core/src/ops/trilu.rs
@@ -329,8 +329,6 @@ def trilu(shape, upper, k):
             false => src.tril(Some(k)),
         }
         .unwrap()
-        .resolve()
-        .unwrap()
         .to(&Device::CPU)
         .unwrap();
 

--- a/crates/ratchet-core/src/ops/trilu.rs
+++ b/crates/ratchet-core/src/ops/trilu.rs
@@ -2,7 +2,7 @@ use derive_new::new;
 use encase::ShaderType;
 use half::f16;
 use inline_wgsl::wgsl;
-use ratchet_macros::WgslMetadata;
+use ratchet_macros::{IrFields, WgslMetadata};
 
 use crate::{
     gpu::BindGroupLayoutDescriptor, rvec, Array, BindingMode, BuiltIn, DType, GPUOperation, Kernel,
@@ -11,7 +11,7 @@ use crate::{
     WorkgroupSize, Workload,
 };
 
-#[derive(new, Debug, Clone)]
+#[derive(new, Debug, Clone, IrFields)]
 pub struct Trilu {
     pub src: Tensor,
     pub upper: bool,

--- a/crates/ratchet-core/src/ops/unary.rs
+++ b/crates/ratchet-core/src/ops/unary.rs
@@ -473,8 +473,7 @@ def {}(a):
             UnaryOp::Reciprocal => a.recip()?,
             UnaryOp::Silu => a.silu()?,
             UnaryOp::Sigmoid => a.sigmoid()?,
-        }
-        .resolve()?;
+        };
 
         let (atol, rtol) = match op {
             UnaryOp::Gelu | UnaryOp::Tanh => (5e-2, 5e-2),

--- a/crates/ratchet-core/src/ops/unary.rs
+++ b/crates/ratchet-core/src/ops/unary.rs
@@ -5,7 +5,7 @@ use derive_new::new;
 use encase::ShaderType;
 use half::f16;
 use inline_wgsl::wgsl;
-use ratchet_macros::WgslMetadata;
+use ratchet_macros::{IrFields, WgslMetadata};
 use strum_macros::EnumIter;
 
 use crate::{
@@ -19,7 +19,7 @@ use crate::{
 use test_strategy::Arbitrary;
 
 #[cfg_attr(test, derive(Arbitrary))]
-#[derive(Debug, Clone, EnumIter)]
+#[derive(Debug, Clone, EnumIter, Hash, IrFields)]
 pub enum UnaryOp {
     Gelu,
     Tanh,
@@ -73,7 +73,7 @@ impl UnaryOp {
     }
 }
 
-#[derive(new, Debug, Clone)]
+#[derive(new, Debug, Clone, IrFields)]
 pub struct Unary {
     pub input: Tensor,
     pub op: UnaryOp,

--- a/crates/ratchet-core/src/ops/unary.rs
+++ b/crates/ratchet-core/src/ops/unary.rs
@@ -411,8 +411,6 @@ mod tests {
         B: usize,
         #[strategy(1..=128usize)]
         M: usize,
-        #[strategy(1..=128usize)]
-        N: usize,
     }
 
     fn ground_truth(a: &Tensor, op: &UnaryOp, args: &str) -> anyhow::Result<Tensor> {
@@ -445,7 +443,7 @@ def {}(a):
     }
 
     fn run_unary_trial(prob: UnaryProblem, device: Device) -> anyhow::Result<()> {
-        let UnaryProblem { op, B, M, N: _ } = prob;
+        let UnaryProblem { op, B, M } = prob;
         let a = Tensor::randn::<f32>(0., 1., shape![B, M], Device::CPU);
 
         let args = match op {

--- a/crates/ratchet-core/src/ops/unary.rs
+++ b/crates/ratchet-core/src/ops/unary.rs
@@ -487,12 +487,14 @@ def {}(a):
 
     #[proptest(cases = 256)]
     fn test_unary_gpu(prob: UnaryProblem) {
+        let _ = env_logger::builder().try_init();
         let device = Device::request_device(DeviceRequest::GPU).unwrap();
         run_unary_trial(prob, device).unwrap();
     }
 
     #[proptest(cases = 256)]
     fn test_unary_cpu(prob: UnaryProblem) {
+        let _ = env_logger::builder().try_init();
         let device = Device::request_device(DeviceRequest::CPU).unwrap();
         run_unary_trial(prob, device).unwrap();
     }

--- a/crates/ratchet-core/src/ops/unary.rs
+++ b/crates/ratchet-core/src/ops/unary.rs
@@ -31,6 +31,7 @@ pub enum UnaryOp {
     Square,
     Sqrt,
     Relu,
+    Relu2,
     Floor,
     Ceil,
     Neg,
@@ -52,6 +53,7 @@ impl UnaryOp {
             UnaryOp::Square => "square".into(),
             UnaryOp::Sqrt => "sqrt".into(),
             UnaryOp::Relu => "relu".into(),
+            UnaryOp::Relu2 => "relu2".into(),
             UnaryOp::Floor => "floor".into(),
             UnaryOp::Ceil => "ceil".into(),
             UnaryOp::Neg => "neg".into(),
@@ -137,6 +139,9 @@ impl KernelRenderable for UnaryKernels {
             UnaryOp::Relu => {
                 kernel_builder.write_global(Unary::render_relu::<P>());
             }
+            UnaryOp::Relu2 => {
+                kernel_builder.write_global(Unary::render_relu2::<P>());
+            }
             _ => {}
         };
 
@@ -212,6 +217,15 @@ impl Unary {
         }
     }
 
+    fn render_relu2<P: WgslPrimitive>() -> String {
+        let accessor = P::render_type();
+
+        wgsl! {
+            fn relu2(val: 'accessor) -> 'accessor {
+                return max(val, 'accessor(0.0)) * max(val, 'accessor(0.0));
+            }
+        }
+    }
     fn render_silu<P: WgslPrimitive>() -> String {
         let accessor = P::render_type();
 
@@ -268,6 +282,7 @@ impl Operation for Unary {
             UnaryOp::Square => "Square",
             UnaryOp::Sqrt => "Sqrt",
             UnaryOp::Relu => "Relu",
+            UnaryOp::Relu2 => "Relu2",
             UnaryOp::Floor => "Floor",
             UnaryOp::Ceil => "Ceil",
             UnaryOp::Neg => "Neg",
@@ -451,6 +466,7 @@ def {}(a):
             UnaryOp::Square => a.square()?,
             UnaryOp::Sqrt => a.sqrt()?,
             UnaryOp::Relu => a.relu()?,
+            UnaryOp::Relu2 => a.relu2()?,
             UnaryOp::Floor => a.floor()?,
             UnaryOp::Ceil => a.ceil()?,
             UnaryOp::Neg => a.neg()?,

--- a/crates/ratchet-core/src/ops/view.rs
+++ b/crates/ratchet-core/src/ops/view.rs
@@ -1,6 +1,8 @@
 use crate::{rvec, OpGuards, Operation, Shape, StorageView, Strides, Tensor};
 
-#[derive(Debug, derive_new::new, Clone)]
+use ratchet_macros::IrFields;
+
+#[derive(Debug, derive_new::new, Clone, IrFields)]
 pub struct View {
     pub(crate) src: Tensor,
     pub(crate) shape: Shape,

--- a/crates/ratchet-core/src/ops/where_cond.rs
+++ b/crates/ratchet-core/src/ops/where_cond.rs
@@ -268,8 +268,6 @@ def where_cond(a, b, c):
         // Put through a ReLU so some of its entries are 0
         let a = Tensor::randn::<f32>(0., 1., shape![B, M, N], Device::CPU)
             .relu()
-            .unwrap()
-            .resolve()
             .unwrap();
         let b = Tensor::randn::<f32>(0., 1., shape![B, M, N], Device::CPU);
         let c = Tensor::randn::<f32>(0., 1., shape![B, M, N], Device::CPU);
@@ -278,7 +276,7 @@ def where_cond(a, b, c):
         let a_gpu = a.to(&device).unwrap();
         let b_gpu = b.to(&device).unwrap();
         let c_gpu = c.to(&device).unwrap();
-        let b = a_gpu.where_cond(b_gpu, c_gpu).unwrap().resolve().unwrap();
+        let b = a_gpu.where_cond(b_gpu, c_gpu).unwrap();
 
         let ours = b.to(&Device::CPU).unwrap();
 

--- a/crates/ratchet-core/src/ops/where_cond.rs
+++ b/crates/ratchet-core/src/ops/where_cond.rs
@@ -2,7 +2,7 @@ use derive_new::new;
 use encase::ShaderType;
 use half::f16;
 use inline_wgsl::wgsl;
-use ratchet_macros::WgslMetadata;
+use ratchet_macros::{IrFields, WgslMetadata};
 
 use crate::{
     gpu::{dtype::WgslDType, BindGroupLayoutDescriptor},
@@ -11,7 +11,7 @@ use crate::{
     Tensor, Vec2, Vec4, WgslKernelBuilder, WgslPrimitive, WorkgroupSize, Workload,
 };
 
-#[derive(new, Debug, Clone)]
+#[derive(new, Debug, Clone, IrFields)]
 pub struct WhereCond {
     pub input: Tensor,
     pub on_true: Tensor,

--- a/crates/ratchet-core/src/shape.rs
+++ b/crates/ratchet-core/src/shape.rs
@@ -285,6 +285,12 @@ impl From<Shape> for glam::IVec3 {
     }
 }
 
+impl From<Shape> for RVec<usize> {
+    fn from(shape: Shape) -> Self {
+        shape.0
+    }
+}
+
 macro_rules! impl_try_into_arr_for_shape {
     ($($N:expr),*) => {
         $(

--- a/crates/ratchet-core/src/storage/cpu_buffer.rs
+++ b/crates/ratchet-core/src/storage/cpu_buffer.rs
@@ -130,7 +130,9 @@ impl CPUBuffer {
         let buf_slice =
             unsafe { std::slice::from_raw_parts_mut(buf.as_mut_ptr() as *mut u8, n_bytes) };
         reader.read_exact(buf_slice).unwrap();
-        let buf = unsafe { std::mem::transmute::<_, Vec<u8>>(buf) };
+        let buf = unsafe {
+            std::mem::transmute::<std::vec::Vec<std::mem::MaybeUninit<u8>>, std::vec::Vec<u8>>(buf)
+        };
         Ok(Self::from_bytes(&buf, dt.size_of()))
     }
 

--- a/crates/ratchet-core/src/storage/gpu_buffer.rs
+++ b/crates/ratchet-core/src/storage/gpu_buffer.rs
@@ -149,7 +149,12 @@ impl GPUBuffer {
     #[cfg(feature = "plotting")]
     pub fn plot_fmt(&self) -> String {
         let id_string = Self::trim_id(self.inner().global_id()).unwrap_or_default();
-        format!("GPU:#{}\n{} bytes", id_string, self.inner.size())
+        format!(
+            "GPU:#{}\n({:?})\n{} bytes",
+            id_string,
+            self.inner.handle,
+            self.inner.size()
+        )
     }
 }
 

--- a/crates/ratchet-core/src/tensor.rs
+++ b/crates/ratchet-core/src/tensor.rs
@@ -1775,7 +1775,7 @@ impl Tensor {
     pub fn to_py<'s, 'p: 's, T: TensorDType + numpy::Element>(
         &'s self,
         py: &'p pyo3::Python<'p>,
-    ) -> &PyArrayDyn<T> {
+    ) -> &'s PyArrayDyn<T> {
         use numpy::PyArray;
         assert!(
             self.device().is_cpu(),
@@ -2072,7 +2072,7 @@ impl std::ops::Div<Tensor> for f32 {
     }
 }
 
-impl<'data> safetensors::View for &'data Tensor {
+impl safetensors::View for &Tensor {
     fn dtype(&self) -> safetensors::Dtype {
         match self.dt() {
             DType::F32 => safetensors::Dtype::F32,

--- a/crates/ratchet-core/src/tensor.rs
+++ b/crates/ratchet-core/src/tensor.rs
@@ -1,8 +1,8 @@
 use crate::gpu::{BindGroupEntry, CpuUniform, WgpuDevice};
 use crate::{
-    cpu, ops::*, rvec, shape, BufferSegment, CPUBuffer, CompiledOp, DType, Device, DeviceStorage,
-    Executable, GPUBuffer, GPUOperation, InvariantError, LazyOp, Operation, OperationError, RVec,
-    RawCPUBuffer, Shape, Storage, Strides, TensorDType, TensorId,
+    cpu, ops::*, rvec, shape, BufferSegment, CPUBuffer, Compiled, CompiledOp, ComputeCompileKey,
+    DType, Device, DeviceStorage, GPUOperation, GpuCompileKey, InvariantError, LazyOp, Operation,
+    OperationError, RVec, RawCPUBuffer, Shape, Storage, Strides, TensorDType, TensorId,
 };
 use bitvec::prelude::*;
 use derive_new::new;
@@ -12,6 +12,7 @@ use num_traits::AsPrimitive;
 use parking_lot::{RwLock, RwLockReadGuard};
 use std::borrow::Cow;
 use std::io::{BufRead, Seek};
+use std::mem::ManuallyDrop;
 use std::ops::Bound;
 use std::path::Path;
 use std::sync::Arc;
@@ -54,7 +55,24 @@ pub struct Tensor {
 
 unsafe impl Send for Tensor {}
 
+macro_rules! ensure_resolved {
+    ($self:ident) => {
+        if !$self.resolved() {
+            $self
+                .apply_pending_graph()
+                .expect("Failed to apply pending graph");
+        }
+    };
+}
+
 impl Tensor {
+    fn register_with_device(&self) {
+        if let Device::GPU(inner) = self.device() {
+            log::trace!("Attempting to register tensor {:?}", self.id());
+            inner.register_tensor(self);
+        }
+    }
+
     pub(crate) fn new_impl(
         op: LazyOp,
         meta: StorageView,
@@ -62,9 +80,11 @@ impl Tensor {
         device: Device,
         is_variable: bool,
     ) -> Self {
-        Self {
-            inner: Arc::new(Inner::new(op, meta, storage, device, is_variable)),
-        }
+        let value = Self {
+            inner: Arc::new(Inner::new(op, meta, storage, device.clone(), is_variable)),
+        };
+        value.register_with_device();
+        value
     }
 
     pub fn new(op: LazyOp, meta: StorageView, storage: Option<Storage>, device: Device) -> Self {
@@ -115,9 +135,11 @@ impl Tensor {
         device: Device,
         is_variable: bool,
     ) -> Self {
-        Self {
+        let value = Self {
             inner: Arc::new(Inner::from_shallow(op, meta, storage, device, is_variable)),
-        }
+        };
+        value.register_with_device();
+        value
     }
 
     pub fn strong_count(&self) -> usize {
@@ -189,6 +211,19 @@ impl StorageView {
     }
 }
 
+impl Drop for Inner {
+    fn drop(&mut self) {
+        if let Device::GPU(inner) = &self.device {
+            log::trace!("Attempting to unregister tensor {:?}", self.id);
+            inner.unregister_tensor(self.id);
+        }
+
+        unsafe {
+            ManuallyDrop::drop(&mut self.storage);
+        }
+    }
+}
+
 #[derive(Debug)]
 pub struct Inner {
     id: TensorId,
@@ -196,7 +231,7 @@ pub struct Inner {
     device: Device,
     view: StorageView,
     is_variable: bool,
-    storage: Arc<RwLock<Option<Storage>>>,
+    storage: ManuallyDrop<Arc<RwLock<Option<Storage>>>>,
 }
 
 impl AsRef<Inner> for Inner {
@@ -218,7 +253,7 @@ impl Inner {
             view: meta,
             op,
             device,
-            storage: Arc::new(RwLock::new(storage)),
+            storage: ManuallyDrop::new(Arc::new(RwLock::new(storage))),
             is_variable,
         }
     }
@@ -235,7 +270,7 @@ impl Inner {
             view: meta,
             op,
             device,
-            storage,
+            storage: ManuallyDrop::new(storage),
             is_variable,
         }
     }
@@ -723,7 +758,7 @@ impl Tensor {
             );
         }
         let device = self.device.clone();
-        let storage = self.storage.clone();
+        let storage = Arc::clone(&self.storage);
         let op = View::new(self, shape);
         let out_view = op.compute_view()?;
 
@@ -1394,21 +1429,16 @@ impl Tensor {
     ///
     /// If the tensor has more than 1 reference, you die.
     /// If the tensor has no storage, you die.
-    pub unsafe fn into_bytes(self) -> anyhow::Result<Vec<u8>> {
-        let inner = Arc::try_unwrap(self.inner).map_err(|_| {
+    pub fn into_bytes(self) -> anyhow::Result<Vec<u8>> {
+        let mut inner = Arc::try_unwrap(self.inner).map_err(|_| {
             anyhow::anyhow!("Cannot convert tensor into bytes with multiple references.")
         })?;
-        let storage = Arc::try_unwrap(inner.storage)
-            .unwrap()
-            .into_inner()
-            .unwrap();
+        let storage = unsafe { ManuallyDrop::take(&mut inner.storage) };
+        let storage = Arc::try_unwrap(storage).unwrap().into_inner().unwrap();
         Ok(storage.into_bytes())
     }
 
-    /// # Safety
-    ///
-    /// Inherited from `Storage::from_quantized`.
-    pub unsafe fn from_quantized<T: TensorDType, U: AsRef<[T]>>(
+    pub fn from_quantized<T: TensorDType, U: AsRef<[T]>>(
         data: U,
         dt: DType,
         shape: Shape,
@@ -1440,7 +1470,7 @@ impl Tensor {
 
     pub fn item<T: TensorDType>(&self) -> T {
         assert!(self.is_scalar());
-        assert!(self.device().is_cpu());
+        ensure_resolved!(self);
         let storage_guard = self.storage();
         let buffer = storage_guard.as_ref().unwrap().try_cpu().unwrap();
         buffer.to_slice::<T>(self.shape())[0]
@@ -1486,7 +1516,7 @@ impl Tensor {
     ///
     /// The 1D vector contains the data from the tensor, as it was laid out in memory.
     pub fn to_vec<T: TensorDType>(&self) -> anyhow::Result<Vec<T>> {
-        assert!(self.device().is_cpu());
+        ensure_resolved!(self);
         let storage_guard = self.storage();
         let buffer = storage_guard.as_ref().unwrap().try_cpu()?;
         let slice = buffer.to_slice::<T>(self.shape());
@@ -1540,64 +1570,77 @@ impl Tensor {
         order
     }
 
-    pub fn compile_gpu_for_op(
-        &self,
-        op: &LazyOp,
-        uniform: &mut CpuUniform,
-        device: &WgpuDevice,
-        can_ip: bool,
-        debug: bool,
-    ) -> Option<CompiledOp> {
-        match op {
-            LazyOp::Binary(b) => b.compile_gpu(self, uniform, device, can_ip, debug).ok(),
-            LazyOp::Cast(c) => c.compile_gpu(self, uniform, device, can_ip, debug).ok(),
-            LazyOp::Matmul(m) => m.compile_gpu(self, uniform, device, can_ip, debug).ok(),
-            LazyOp::Softmax(s) => s.compile_gpu(self, uniform, device, can_ip, debug).ok(),
-            LazyOp::RoPE(r) => r.compile_gpu(self, uniform, device, can_ip, debug).ok(),
-            LazyOp::Unary(u) => u.compile_gpu(self, uniform, device, can_ip, debug).ok(),
-            LazyOp::Reindex(r) => r.compile_gpu(self, uniform, device, can_ip, debug).ok(),
-            LazyOp::Concat(c) => c.compile_gpu(self, uniform, device, can_ip, debug).ok(),
-            LazyOp::Norm(n) => n.compile_gpu(self, uniform, device, can_ip, debug).ok(),
-            LazyOp::Affine(a) => a.compile_gpu(self, uniform, device, can_ip, debug).ok(),
-            LazyOp::Cmp(c) => c.compile_gpu(self, uniform, device, can_ip, debug).ok(),
-            LazyOp::Powf(p) => p.compile_gpu(self, uniform, device, can_ip, debug).ok(),
-            LazyOp::WhereCond(w) => w.compile_gpu(self, uniform, device, can_ip, debug).ok(),
-            LazyOp::Conv(c) => c.compile_gpu(self, uniform, device, can_ip, debug).ok(),
-            LazyOp::Select(i) => i.compile_gpu(self, uniform, device, can_ip, debug).ok(),
-            LazyOp::IndexWrite(i) => i.compile_gpu(self, uniform, device, can_ip, debug).ok(),
-            LazyOp::IndexAdd(i) => i.compile_gpu(self, uniform, device, can_ip, debug).ok(),
-            LazyOp::ScatterAdd(s) => s.compile_gpu(self, uniform, device, can_ip, debug).ok(),
-            LazyOp::Trilu(t) => t.compile_gpu(self, uniform, device, can_ip, debug).ok(),
-            LazyOp::Cache(c) => c.compile_gpu(self, uniform, device, can_ip, debug).ok(),
-            LazyOp::Reduce(s) => s.compile_gpu(self, uniform, device, can_ip, debug).ok(),
-            LazyOp::Detach(d) => self.compile_gpu_for_op(d, uniform, device, can_ip, debug),
-            LazyOp::Gather(g) => g.compile_gpu(self, uniform, device, can_ip, debug).ok(),
-            LazyOp::FillConstant(f) => f.compile_gpu(self, uniform, device, can_ip, debug).ok(),
-            LazyOp::FillRandn(f) => f.compile_gpu(self, uniform, device, can_ip, debug).ok(),
-            LazyOp::Arange(a) => a.compile_gpu(self, uniform, device, can_ip, debug).ok(),
-            LazyOp::Const => None,
-            LazyOp::View(_) => None,
-        }
-    }
-
     pub fn cpu_apply(self, dst: Tensor) -> Option<Tensor> {
         cpu::apply_operation(self.op().clone(), dst).ok()
     }
 
-    pub fn compile_gpu(
-        &self,
-        uniform: &mut CpuUniform,
-        device: &WgpuDevice,
+    fn gpu_compile_key_for_op<'a>(
+        &'a self,
+        op: &'a LazyOp,
         can_inplace: bool,
-        debug: bool,
-    ) -> Option<CompiledOp> {
-        self.compile_gpu_for_op(&self.op, uniform, device, can_inplace, debug)
+        uniform: &mut CpuUniform,
+    ) -> Option<ComputeCompileKey<'a>> {
+        match op {
+            LazyOp::Binary(b) => b.create_gpu_compile_key(self, can_inplace, uniform).ok(),
+            LazyOp::Cast(c) => c.create_gpu_compile_key(self, can_inplace, uniform).ok(),
+            LazyOp::Matmul(m) => m.create_gpu_compile_key(self, can_inplace, uniform).ok(),
+            LazyOp::Softmax(s) => s.create_gpu_compile_key(self, can_inplace, uniform).ok(),
+            LazyOp::RoPE(r) => r.create_gpu_compile_key(self, can_inplace, uniform).ok(),
+            LazyOp::Unary(u) => u.create_gpu_compile_key(self, can_inplace, uniform).ok(),
+            LazyOp::Reindex(r) => r.create_gpu_compile_key(self, can_inplace, uniform).ok(),
+            LazyOp::Concat(c) => c.create_gpu_compile_key(self, can_inplace, uniform).ok(),
+            LazyOp::Norm(n) => n.create_gpu_compile_key(self, can_inplace, uniform).ok(),
+            LazyOp::Affine(a) => a.create_gpu_compile_key(self, can_inplace, uniform).ok(),
+            LazyOp::Cmp(c) => c.create_gpu_compile_key(self, can_inplace, uniform).ok(),
+            LazyOp::Powf(p) => p.create_gpu_compile_key(self, can_inplace, uniform).ok(),
+            LazyOp::WhereCond(w) => w.create_gpu_compile_key(self, can_inplace, uniform).ok(),
+            LazyOp::Conv(c) => c.create_gpu_compile_key(self, can_inplace, uniform).ok(),
+            LazyOp::Select(i) => i.create_gpu_compile_key(self, can_inplace, uniform).ok(),
+            LazyOp::IndexWrite(i) => i.create_gpu_compile_key(self, can_inplace, uniform).ok(),
+            LazyOp::IndexAdd(i) => i.create_gpu_compile_key(self, can_inplace, uniform).ok(),
+            LazyOp::ScatterAdd(s) => s.create_gpu_compile_key(self, can_inplace, uniform).ok(),
+            LazyOp::Trilu(t) => t.create_gpu_compile_key(self, can_inplace, uniform).ok(),
+            LazyOp::Cache(c) => c.create_gpu_compile_key(self, can_inplace, uniform).ok(),
+            LazyOp::Reduce(s) => s.create_gpu_compile_key(self, can_inplace, uniform).ok(),
+            LazyOp::Detach(d) => self.gpu_compile_key_for_op(d, can_inplace, uniform),
+            LazyOp::Gather(g) => g.create_gpu_compile_key(self, can_inplace, uniform).ok(),
+            LazyOp::FillConstant(f) => f.create_gpu_compile_key(self, can_inplace, uniform).ok(),
+            LazyOp::FillRandn(f) => f.create_gpu_compile_key(self, can_inplace, uniform).ok(),
+            LazyOp::Arange(a) => a.create_gpu_compile_key(self, can_inplace, uniform).ok(),
+            LazyOp::Copy(_) | LazyOp::View(_) | LazyOp::Const => None,
+        }
     }
 
-    fn resolve_inner(self, immediate: bool, debug: bool) -> Result<Tensor, TensorError> {
-        match self.device().clone() {
-            Device::CPU => self.resolve_cpu(),
-            Device::GPU(device) => self.resolve_gpu(&device, immediate, debug),
+    pub fn gpu_compile_key(
+        &self,
+        can_inplace: bool,
+        uniform: &mut CpuUniform,
+    ) -> Option<GpuCompileKey> {
+        match self.op() {
+            LazyOp::Copy(c) => Some(GpuCompileKey::Copy(c.create_gpu_compile_key())),
+            _ => self
+                .gpu_compile_key_for_op(self.op(), can_inplace, uniform)
+                .map(GpuCompileKey::Compute),
+    }
+    }
+
+    pub fn compile_gpu<'a>(
+        &'a self,
+        gpu_compile_key: &GpuCompileKey<'a>,
+        gpu_device: &'a WgpuDevice,
+        debug: bool,
+    ) -> Option<Compiled> {
+        match gpu_compile_key {
+            GpuCompileKey::Copy(_) => {
+                if let LazyOp::Copy(c) = self.op() {
+                    c.compile_gpu().ok()
+                } else {
+                    None
+                }
+            }
+            GpuCompileKey::Compute(compute_key) => {
+                compile_gpu_for_op(self.op(), compute_key, gpu_device, debug).map(Compiled::Compute)
+            }
         }
     }
 
@@ -1617,116 +1660,23 @@ impl Tensor {
         Ok(tensor.clone())
     }
 
-    fn resolve_gpu(
-        self,
-        gpu_device: &WgpuDevice,
-        immediate: bool,
-        debug: bool,
-    ) -> Result<Tensor, TensorError> {
-        let execution_order = self.execution_order();
-        let mut uniform = CpuUniform::new();
-        let mut compiled_ops = Vec::with_capacity(execution_order.len());
-
-        gpu_device.begin_pass();
-        let mut allocations = gpu_device.allocate_cfg(&execution_order, gpu_device)?;
-
-        #[cfg(feature = "plotting")]
-        crate::plot::render_to_file(execution_order.last().unwrap(), "prealloc.svg").unwrap();
-
-        #[cfg(feature = "debug")]
-        let mut compute_dsts = Vec::new();
-
-        for t in execution_order.iter() {
-            log::debug!("Compiling: {:?}", t.op().name());
-            assert!(t.device().is_gpu());
-            if t.resolved() {
-                continue;
-            }
-
-            if t.op().is_const() {
-                Err(TensorError::NotResolved)?;
-            }
-
-            let id = t.id();
-            let inner = allocations.remove(&id).ok_or(TensorError::NoStorage(id))?;
-            t.update_storage(Storage::GPU(GPUBuffer {
-                inner,
-                alignment: t.dt().size_of(),
-                cpu_size: Some(t.num_bytes()),
-            }));
-
-            let srcs = t.op().srcs();
-            let to_modify = srcs.first();
-            let can_inplace = match to_modify {
-                Some(to_modify_src) => {
-                    t.op().supports_inplace()
-                        // vinhowe: we need to check if the src is a variable, because we can't inplace
-                        // variables unless we've disabled gradient tracking.
-                        && !t.is_variable()
-                        && to_modify_src.strong_count() == 1
-                }
-                None => false,
-            };
-
-            if let Some(compiled_op) = t.compile_gpu(&mut uniform, gpu_device, can_inplace, debug) {
-                compiled_ops.push(compiled_op);
-                #[cfg(feature = "debug")]
-                compute_dsts.push(*t);
-            } else {
-                log::warn!("Compilation failed for operation: {:?}", t.op().name());
-            }
-        }
-        #[cfg(feature = "plotting")]
-        crate::plot::render_to_file(execution_order.last().unwrap(), "alloc.svg").unwrap();
-
-        let executable = Executable::new(
-            compiled_ops,
-            uniform.into_gpu(gpu_device)?,
-            #[cfg(feature = "debug")]
-            compute_dsts,
-        );
-
-        #[cfg(feature = "debug")]
-        let index = if debug {
-            if cfg!(feature = "debug") {
-                executable.dispatch_debugging(gpu_device).unwrap()
-            } else {
-                panic!("Debugging is only available in debug builds. Call `resolve()` instead of `resolve_debug()`.")
-            }
-        } else {
-            executable.dispatch(gpu_device).unwrap()
-        };
-
-        #[cfg(not(feature = "debug"))]
-        let index = executable.dispatch(gpu_device).unwrap();
-        if immediate {
-            gpu_device.poll(wgpu::MaintainBase::WaitForSubmissionIndex(index));
+    /// Applies the pending graph to the tensor.
+    fn apply_pending_graph(&self) -> Result<Tensor, TensorError> {
+        if self.resolved() {
+            return Ok(self.clone());
         }
 
-        Ok(self)
+        match self.device() {
+            Device::GPU(gpu_device) => {
+                gpu_device.sync_tensors_graph(vec![&self])?;
+                Ok(self.clone())
     }
-
-    pub fn resolve(self) -> Result<Tensor, TensorError> {
-        self.resolve_inner(true, false)
-    }
-
-    pub fn resolve_deferred(self) -> Result<Tensor, TensorError> {
-        self.resolve_inner(false, false)
-    }
-
-    /// Resolves the tensor computations and copies the output
-    /// from each operation to a debug buffer.
-    ///
-    /// The copy calls are inserted between each operation, so inplace
-    /// operations are captured.
-    pub fn resolve_debug(self) -> Result<Tensor, TensorError> {
-        self.resolve_inner(true, true)
+            Device::CPU => self.clone().resolve_cpu(),
+        }
     }
 
     fn to_gpu(&self, dst_device: &Device) -> Result<Tensor, TensorError> {
-        if self.device().is_gpu() || !self.resolved() {
-            return Ok(self.clone());
-        }
+        ensure_resolved!(self);
         let storage_guard = self.storage();
         let cpu_buf = storage_guard
             .as_ref()
@@ -1745,6 +1695,7 @@ impl Tensor {
     }
 
     pub fn deep_clone(&self) -> Tensor {
+        ensure_resolved!(self);
         let storage_guard = self.storage();
         let storage = storage_guard.as_ref().unwrap();
         let cloned_storage = storage.deep_clone(self.device()).unwrap();
@@ -1755,14 +1706,13 @@ impl Tensor {
             self.device.clone(),
             false,
         )
-    }
 }
 
-impl Tensor {
     #[maybe_async]
     async fn to_cpu(&self) -> Result<Tensor, TensorError> {
-        if self.device().is_cpu() || !self.resolved() {
-            log::error!("Tensor may not have been resolved, try calling `resolve()` first.");
+        ensure_resolved!(self);
+
+        if self.device().is_cpu() {
             return Ok(self.clone());
         }
         let storage_guard = self.storage();
@@ -1806,6 +1756,44 @@ impl Tensor {
             "Cannot convert non-CPU tensor to numpy array"
         );
         PyArray::from_owned_array(*py, self.deep_clone().into_ndarray::<T>())
+    }
+}
+
+pub fn compile_gpu_for_op(
+    op: &LazyOp,
+    gpu_compile_key: &ComputeCompileKey,
+    gpu_device: &WgpuDevice,
+    debug: bool,
+) -> Option<CompiledOp> {
+    match op {
+        LazyOp::Binary(b) => b.compile_gpu(gpu_compile_key, gpu_device, debug).ok(),
+        LazyOp::Cast(c) => c.compile_gpu(gpu_compile_key, gpu_device, debug).ok(),
+        LazyOp::Matmul(m) => m.compile_gpu(gpu_compile_key, gpu_device, debug).ok(),
+        LazyOp::Softmax(s) => s.compile_gpu(gpu_compile_key, gpu_device, debug).ok(),
+        LazyOp::RoPE(r) => r.compile_gpu(gpu_compile_key, gpu_device, debug).ok(),
+        LazyOp::Unary(u) => u.compile_gpu(gpu_compile_key, gpu_device, debug).ok(),
+        LazyOp::Reindex(r) => r.compile_gpu(gpu_compile_key, gpu_device, debug).ok(),
+        LazyOp::Concat(c) => c.compile_gpu(gpu_compile_key, gpu_device, debug).ok(),
+        LazyOp::Norm(n) => n.compile_gpu(gpu_compile_key, gpu_device, debug).ok(),
+        LazyOp::Affine(a) => a.compile_gpu(gpu_compile_key, gpu_device, debug).ok(),
+        LazyOp::Cmp(c) => c.compile_gpu(gpu_compile_key, gpu_device, debug).ok(),
+        LazyOp::Powf(p) => p.compile_gpu(gpu_compile_key, gpu_device, debug).ok(),
+        LazyOp::WhereCond(w) => w.compile_gpu(gpu_compile_key, gpu_device, debug).ok(),
+        LazyOp::Conv(c) => c.compile_gpu(gpu_compile_key, gpu_device, debug).ok(),
+        LazyOp::Select(i) => i.compile_gpu(gpu_compile_key, gpu_device, debug).ok(),
+        LazyOp::IndexWrite(i) => i.compile_gpu(gpu_compile_key, gpu_device, debug).ok(),
+        LazyOp::IndexAdd(i) => i.compile_gpu(gpu_compile_key, gpu_device, debug).ok(),
+        LazyOp::ScatterAdd(s) => s.compile_gpu(gpu_compile_key, gpu_device, debug).ok(),
+        LazyOp::Trilu(t) => t.compile_gpu(gpu_compile_key, gpu_device, debug).ok(),
+        LazyOp::Cache(c) => c.compile_gpu(gpu_compile_key, gpu_device, debug).ok(),
+        LazyOp::Reduce(s) => s.compile_gpu(gpu_compile_key, gpu_device, debug).ok(),
+        LazyOp::Detach(d) => compile_gpu_for_op(d, gpu_compile_key, gpu_device, debug),
+        LazyOp::Gather(g) => g.compile_gpu(gpu_compile_key, gpu_device, debug).ok(),
+        LazyOp::FillConstant(f) => f.compile_gpu(gpu_compile_key, gpu_device, debug).ok(),
+        LazyOp::FillRandn(f) => f.compile_gpu(gpu_compile_key, gpu_device, debug).ok(),
+        LazyOp::Arange(a) => a.compile_gpu(gpu_compile_key, gpu_device, debug).ok(),
+        LazyOp::View(_) | LazyOp::Const => None,
+        LazyOp::Copy(_) => panic!("Copy should not have a gpu_compile_key"),
     }
 }
 
@@ -1928,9 +1916,7 @@ impl Tensor {
     }
 
     pub fn to_ndarray_view<T: TensorDType>(&self) -> ArrayViewD<T> {
-        if !self.resolved() {
-            panic!("Tensor is not resolved");
-        }
+        ensure_resolved!(self);
         assert!(self.device().is_cpu());
         assert!(self.dt() == T::dt());
         let shape = self.shape().to_vec();
@@ -2139,10 +2125,7 @@ mod tests {
         let rand = Tensor::randn::<f32>(0., 1., shape![1, 1500, 384], device.clone());
         let nans = Tensor::from_data(vec![f32::NAN; 1500 * 384], shape![1, 1500, 384], device);
 
-        let bingo = Tensor::cat(rvec![rand, nans], 2)
-            .unwrap()
-            .resolve()
-            .unwrap();
+        let bingo = Tensor::cat(rvec![rand, nans], 2).unwrap();
 
         let result = bingo.to(&Device::CPU).unwrap();
         println!("RESULT: {:?}", result);

--- a/crates/ratchet-core/src/tensor.rs
+++ b/crates/ratchet-core/src/tensor.rs
@@ -1454,7 +1454,6 @@ impl Tensor {
         reader: &mut R,
         shape: Shape,
         device: Device,
-        is_variable: bool,
     ) -> anyhow::Result<Tensor> {
         let storage = Storage::from_disk::<T, R>(reader, &shape, &device)?;
         let strides = Strides::from(&shape);
@@ -1464,7 +1463,7 @@ impl Tensor {
             meta,
             Some(storage),
             device,
-            is_variable,
+            false,
         ))
     }
 

--- a/crates/ratchet-core/src/tensor.rs
+++ b/crates/ratchet-core/src/tensor.rs
@@ -1370,6 +1370,19 @@ impl Tensor {
         }
     }
 
+    pub fn copy(&self, dst: &Self) -> Tensor {
+        Tensor::new_impl(
+            LazyOp::Copy(TensorCopy {
+                src: self.clone(),
+                dst: dst.clone(),
+            }),
+            self.view.clone(),
+            None,
+            self.device.clone(),
+            false,
+        )
+    }
+
     pub(crate) fn same_storage(&self, rhs: &Self) -> bool {
         match (self.storage().as_ref(), rhs.storage().as_ref()) {
             (Some(lhs), Some(rhs)) => std::ptr::eq(lhs, rhs),

--- a/crates/ratchet-core/src/tensor.rs
+++ b/crates/ratchet-core/src/tensor.rs
@@ -413,6 +413,7 @@ impl Tensor {
     impl_unary_op!(abs, UnaryOp::Abs);
     impl_unary_op!(sqrt, UnaryOp::Sqrt);
     impl_unary_op!(relu, UnaryOp::Relu);
+    impl_unary_op!(relu2, UnaryOp::Relu2);
     impl_unary_op!(floor, UnaryOp::Floor);
     impl_unary_op!(ceil, UnaryOp::Ceil);
     impl_unary_op!(neg, UnaryOp::Neg);

--- a/crates/ratchet-core/src/tensor_id.rs
+++ b/crates/ratchet-core/src/tensor_id.rs
@@ -8,6 +8,18 @@ impl std::fmt::Debug for TensorId {
     }
 }
 
+impl Ord for TensorId {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.0.cmp(&other.0)
+    }
+}
+
+impl PartialOrd for TensorId {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
 impl TensorId {
     pub(crate) fn new() -> Self {
         // https://users.rust-lang.org/t/idiomatic-rust-way-to-generate-unique-id/33805

--- a/crates/ratchet-core/src/variable.rs
+++ b/crates/ratchet-core/src/variable.rs
@@ -34,6 +34,15 @@ impl Var {
         Self(inner)
     }
 
+    pub fn full<T: TensorDType + AsPrimitive<f32>>(
+        shape: &Shape,
+        value: T,
+        device: &Device,
+    ) -> Self {
+        let inner = Tensor::full_impl::<T>(shape, value, device, true);
+        Self(inner)
+    }
+
     // Convert a tensor to a variable, if the tensor is already a variable then it is returned as is.
     pub fn from_tensor(t: &Tensor) -> Result<Self> {
         if t.is_variable() {

--- a/crates/ratchet-core/src/variable.rs
+++ b/crates/ratchet-core/src/variable.rs
@@ -113,7 +113,7 @@ impl Var {
 
     /// Sets the content of the inner tensor, this does not require a mutable reference as inner
     /// mutability is used.
-    pub fn set(&self, src: Tensor) -> Result<()> {
+    pub fn set_sync(&self, src: Tensor) -> Result<()> {
         if self.as_tensor().same_storage(&src) {
             panic!("cannot set a variable to a tensor that is derived from its value");
         }
@@ -133,5 +133,9 @@ impl Var {
             cpu_size: Some(dst.num_bytes()),
         }));
         Ok(())
+    }
+
+    pub fn set(&self, src: Tensor) -> Tensor {
+        src.copy(self.as_tensor())
     }
 }

--- a/crates/ratchet-core/tests/attn_tests.rs
+++ b/crates/ratchet-core/tests/attn_tests.rs
@@ -77,7 +77,7 @@ def scaled_dot_product_attention(input, qw, kw, vw) -> torch.Tensor:
 
         let device = Device::request_device(DeviceRequest::GPU)?;
         let gpu_test_case = cpu_test_case.to_gpu(device.clone());
-        let out = sdpa_cfg(&gpu_test_case, device.clone())?.resolve()?;
+        let out = sdpa_cfg(&gpu_test_case, device.clone())?;
         let out_cpu = out.to(&Device::CPU)?;
         println!("OURS: {:?}\n", out_cpu);
         println!("GROUND: {:?}", ground);
@@ -167,7 +167,7 @@ def qkv_attention(input, qw, kw, vw, n_heads):
 
         let device = Device::request_device(DeviceRequest::GPU)?;
         let gpu_test_case = cpu_test_case.to_gpu(device.clone());
-        let out = mha_cfg(&gpu_test_case, device.clone())?.resolve()?;
+        let out = mha_cfg(&gpu_test_case, device.clone())?;
         let out_cpu = out.to(&Device::CPU)?;
         println!("OURS: {:?}\n", out_cpu);
         println!("GROUND: {:?}", ground);

--- a/crates/ratchet-macros/Cargo.toml
+++ b/crates/ratchet-macros/Cargo.toml
@@ -18,3 +18,4 @@ std = []
 proc-macro2 = { version = "1.0" }
 quote = { version = "1.0" }
 syn = { version = "2.0" }
+heck = { version = "0.5.0" }

--- a/crates/ratchet-macros/src/ir_fields.rs
+++ b/crates/ratchet-macros/src/ir_fields.rs
@@ -1,0 +1,70 @@
+use heck::ToSnakeCase;
+use proc_macro2::TokenStream;
+use quote::quote;
+use syn::{parse2, DeriveInput};
+
+pub fn derive(input: TokenStream) -> TokenStream {
+    let input = parse2::<DeriveInput>(input).unwrap();
+    let struct_name = input.ident;
+
+    let (with_fields, match_arms) = match input.data {
+        syn::Data::Struct(data_struct) => {
+            let with_fields = data_struct.fields.iter().enumerate().map(|(i, field)| {
+                let (field_name, field_access) = match &field.ident {
+                    Some(ident) => (quote! { stringify!(#ident) }, quote! { #ident }),
+                    None => {
+                        let index = syn::Index::from(i);
+                        let field_name =
+                            syn::LitStr::new(&i.to_string(), proc_macro2::Span::call_site());
+                        (quote! { #field_name }, quote! { #index })
+                    }
+                };
+                quote! {
+                    .with_field(#field_name, self.#field_access.clone())
+                }
+            });
+            (Some(with_fields.collect::<Vec<_>>()), None)
+        }
+        syn::Data::Enum(data_enum) => {
+            let snake_name = struct_name.to_string().to_snake_case();
+            let match_arms = data_enum.variants.iter().map(|variant| {
+                if variant.fields.len() > 1 {
+                    panic!("Enum variants with multiple fields are not supported");
+                }
+                let variant_ident = &variant.ident;
+
+                if variant.fields.is_empty() {
+                    return quote! {
+                        #struct_name::#variant_ident => {
+                            ir.with_field(#snake_name, stringify!(#variant_ident));
+                        }
+                    };
+                }
+
+                quote! {
+                    #struct_name::#variant_ident(inner) => {
+                        ir.with_field(#snake_name, stringify!(#variant_ident));
+                        inner.ir_fields(ir);
+                    }
+                }
+            });
+            let match_arms = quote! { match self { #(#match_arms)* } };
+
+            (None, Some(match_arms))
+        }
+        _ => panic!("Only structs and enums are supported"),
+    };
+
+    let with_fields_statement = with_fields.map(|fields| quote! { ir #(#fields)*; });
+
+    let expanded = quote! {
+        impl crate::IrFields for #struct_name {
+            fn ir_fields(&self, ir: &mut crate::Ir) {
+                #with_fields_statement
+                #match_arms
+            }
+        }
+    };
+
+    expanded
+}

--- a/crates/ratchet-macros/src/lib.rs
+++ b/crates/ratchet-macros/src/lib.rs
@@ -1,3 +1,4 @@
+mod ir_fields;
 mod wgsl_metadata;
 
 use proc_macro::TokenStream;
@@ -10,4 +11,13 @@ use syn::parse_macro_input;
 pub fn derive_wgsl_metadata(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input);
     wgsl_metadata::derive(input).into()
+}
+
+/// Derives the `IrFields` trait implementation for a struct.
+///
+/// Generates a `.ir_fields()` method we use for hashing compute graphs.
+#[proc_macro_derive(IrFields, attributes(builder))]
+pub fn derive_ir_fields(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input);
+    ir_fields::derive(input).into()
 }

--- a/crates/ratchet-models/src/gpt2/generate.rs
+++ b/crates/ratchet-models/src/gpt2/generate.rs
@@ -32,7 +32,7 @@ pub async fn generate(
             shape![1, tokens.len()],
             model.device.clone(),
         );
-        let result = model.schedule(input)?.resolve()?;
+        let result = model.schedule(input)?;
         let logits = result.to(&Device::CPU).await?;
         model.cache_mut().update(tokens.len());
 

--- a/crates/ratchet-models/src/gpt2/model.rs
+++ b/crates/ratchet-models/src/gpt2/model.rs
@@ -257,9 +257,9 @@ mod tests {
 
             // clip_grad_norm(&mut grads, 1.0f32, &device)?;
 
-            opt.step(&grads)?;
+            opt.step(&grads, &device)?;
 
-            let loss_vec = loss.clone().resolve()?.to(&Device::CPU)?.to_vec::<f32>()?;
+            let loss_vec = loss.clone().to(&Device::CPU)?.to_vec::<f32>()?;
 
             println!("{:?} loss: {:?}", step, loss_vec[0]);
         }
@@ -303,7 +303,9 @@ mod tests {
 
             let loss = cross_entropy(logits.flatten_to(1)?, tgt.flatten_to(1)?)?;
 
-            let loss_vec = loss.clone().resolve()?.to(&Device::CPU)?.to_vec::<f32>()?;
+            device.try_gpu()?.mark_step()?;
+
+            let loss_vec = loss.clone().to(&Device::CPU)?.to_vec::<f32>()?;
 
             println!("{:?} loss: {:?}", batch_index, loss_vec[0]);
         }
@@ -374,9 +376,9 @@ mod tests {
 
             let grads = loss.backward()?;
 
-            opt.step(&grads)?;
+            opt.step(&grads, &device)?;
 
-            let loss_vec = loss.clone().resolve()?.to(&Device::CPU)?.to_vec::<f32>()?;
+            let loss_vec = loss.clone().to(&Device::CPU)?.to_vec::<f32>()?;
 
             println!("{:?} loss: {:?}, norm: {:?}", batch_index, loss_vec[0], "?");
         }
@@ -449,9 +451,9 @@ mod tests {
             // This is something of a hack; we add references to all tensors that need to be backpropped
             let grads = loss.backward()?;
 
-            opt.step(&grads)?;
+            opt.step(&grads, &device)?;
 
-            let loss_vec = loss.resolve_deferred()?.to(&Device::CPU)?.to_vec::<f32>()?;
+            let loss_vec = loss.to(&Device::CPU)?.to_vec::<f32>()?;
 
             println!("{:?} loss: {:?}", batch_index, loss_vec[0]);
         }

--- a/crates/ratchet-models/src/gpt2/model.rs
+++ b/crates/ratchet-models/src/gpt2/model.rs
@@ -212,7 +212,7 @@ mod tests {
 
         let config = Config {
             vocab_size: VOCAB_SIZE,
-            hidden_act: ratchet_nn::Activation::Gelu,
+            hidden_act: ratchet_nn::Activation::Relu2,
             n_embd: 128,
             n_layer: 4,
             n_head: 4,
@@ -278,7 +278,7 @@ mod tests {
 
         let config = Config {
             vocab_size: VOCAB_SIZE,
-            hidden_act: ratchet_nn::Activation::Gelu,
+            hidden_act: ratchet_nn::Activation::Relu2,
             n_embd: 128,
             n_layer: 1,
             n_head: 1,
@@ -325,7 +325,7 @@ mod tests {
 
         let config = Config {
             vocab_size: VOCAB_SIZE,
-            hidden_act: ratchet_nn::Activation::Gelu,
+            hidden_act: ratchet_nn::Activation::Relu2,
             n_embd: 768,
             n_layer: 4,
             n_head: 4,
@@ -411,7 +411,7 @@ mod tests {
         // distilgpt2-sized
         let config = Config {
             vocab_size: VOCAB_SIZE,
-            hidden_act: ratchet_nn::Activation::Gelu,
+            hidden_act: ratchet_nn::Activation::Relu2,
             n_embd: 768,
             n_layer: 12,
             n_head: 12,

--- a/crates/ratchet-nn/Cargo.toml
+++ b/crates/ratchet-nn/Cargo.toml
@@ -24,6 +24,7 @@ thiserror = { workspace = true }
 ndarray = { workspace = true }
 async-trait = { workspace = true }
 num-traits = { workspace = true }
+env_logger = { workspace = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 maybe-async = { workspace = true, features = ["is_sync"] }

--- a/crates/ratchet-nn/Cargo.toml
+++ b/crates/ratchet-nn/Cargo.toml
@@ -42,9 +42,5 @@ tokenizers = { version = "0.19.1", default-features = false, features = [
 ] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies.web-sys]
-features = [
-    "Blob",
-    "HtmlAnchorElement",
-    "CssStyleDeclaration"
-]
+features = ["Blob", "HtmlAnchorElement", "CssStyleDeclaration"]
 workspace = true

--- a/crates/ratchet-nn/src/activation.rs
+++ b/crates/ratchet-nn/src/activation.rs
@@ -18,7 +18,7 @@ impl Module for Activation {
         match self {
             Self::Gelu => input.gelu(),
             Self::Relu => input.relu(),
-            Self::Relu2 => input.relu()?.square(),
+            Self::Relu2 => input.relu2(),
             Self::Silu => input.silu(),
             Self::Sigmoid => input.sigmoid(),
         }

--- a/crates/ratchet-nn/src/embedding.rs
+++ b/crates/ratchet-nn/src/embedding.rs
@@ -136,7 +136,7 @@ def embedding(weight, indices):
         let indices = indices.to(&device).unwrap();
 
         let embedding = Embedding::new(weight);
-        let result = embedding.schedule(indices).unwrap().resolve().unwrap();
+        let result = embedding.schedule(indices).unwrap();
         let x = result.to(&Device::CPU).unwrap();
         ground_truth.all_close(&x, 1e-6, 1e-6).unwrap();
     }

--- a/crates/ratchet-nn/src/init.rs
+++ b/crates/ratchet-nn/src/init.rs
@@ -112,11 +112,9 @@ impl Init {
     /// Creates a new tensor with the specified shape, device, and initialization.
     pub fn var(&self, s: &Shape, device: Device) -> anyhow::Result<Var> {
         match self {
-            Self::Const(v) if *v == 0. => Ok(Var::zeros::<f32>(&s, &device)),
-            Self::Const(v) if *v == 1. => Ok(Var::ones::<f32>(&s, &device)),
-            Self::Const(cst) => {
-                Var::from_tensor(&Tensor::ones::<f32>(&s, &device).affine(*cst as f32, 0.)?)
-            }
+            Self::Const(v) if *v == 0. => Ok(Var::zeros::<f32>(s, &device)),
+            Self::Const(v) if *v == 1. => Ok(Var::ones::<f32>(s, &device)),
+            Self::Const(cst) => Ok(Var::full(s, *cst, &device)),
             Self::Uniform { lo, up } => Ok(Var::rand::<f32>(*lo, *up, s.clone(), device)),
             Self::Randn { mean, stdev } => Ok(Var::randn::<f32>(*mean, *stdev, s.clone(), device)),
             Self::Kaiming {

--- a/crates/ratchet-nn/src/lib.rs
+++ b/crates/ratchet-nn/src/lib.rs
@@ -36,9 +36,6 @@ use ratchet::Tensor;
 /// In PyTorch, `forward` performs the computation when called. In Ratchet, `schedule` is used to
 /// schedule the computation for future execution. The Tensor returned is lazy, in that it
 /// represents the result of the computation, but the computation itself has not been performed.
-///
-/// If you want to immediately access the result of the computation (say for debugging), call
-/// `.resolve()` on the Tensor to execute the work.
 pub trait Module {
     type Input;
     fn schedule(&self, input: Self::Input) -> anyhow::Result<Tensor>;

--- a/crates/ratchet-nn/src/linear.rs
+++ b/crates/ratchet-nn/src/linear.rs
@@ -148,7 +148,7 @@ def linear(x, w):
             linear.w.to(&device)?,
             linear.b.map(|b| b.to(&device)).transpose()?,
         );
-        let result_gpu = linear_gpu.schedule(x_gpu)?.resolve()?;
+        let result_gpu = linear_gpu.schedule(x_gpu)?;
 
         let ours = result_gpu.to(&Device::CPU)?;
         println!("x = {:?}", x);
@@ -257,8 +257,8 @@ def linear_backward(x, w):
 
         let result_gpu = linear.schedule(x_var.as_tensor().clone())?;
 
-        let mut grads = result_gpu.backward()?;
-        grads.resolve(device.try_gpu()?)?;
+        let grads = result_gpu.backward()?;
+        device.try_gpu()?.mark_step()?;
 
         let x_grad = grads.get(&x_var.as_tensor()).unwrap().to(&Device::CPU)?;
         let w_grad = grads.get(&linear.w).unwrap().to(&Device::CPU)?;

--- a/crates/ratchet-nn/src/linear.rs
+++ b/crates/ratchet-nn/src/linear.rs
@@ -260,7 +260,7 @@ def linear_backward(x, w):
         let grads = result_gpu.backward()?;
         device.try_gpu()?.mark_step()?;
 
-        let x_grad = grads.get(&x_var.as_tensor()).unwrap().to(&Device::CPU)?;
+        let x_grad = grads.get(x_var.as_tensor()).unwrap().to(&Device::CPU)?;
         let w_grad = grads.get(&linear.w).unwrap().to(&Device::CPU)?;
         let b_grad = match &linear.b {
             Some(b) => Some(grads.get(b).unwrap().to(&Device::CPU)?),

--- a/crates/ratchet-nn/src/linear.rs
+++ b/crates/ratchet-nn/src/linear.rs
@@ -83,9 +83,7 @@ mod tests {
 
     use super::{linear, linear_no_bias, Linear};
     use ratchet::{
-        prelude::shape,
-        test_util::{run_py_prg, run_py_prg_multiple},
-        Device, DeviceRequest, Tensor, Var,
+        prelude::shape, test_util::run_py_prg_multiple, Device, DeviceRequest, Tensor, Var,
     };
     use test_strategy::{proptest, Arbitrary};
 

--- a/crates/ratchet-nn/src/loss.rs
+++ b/crates/ratchet-nn/src/loss.rs
@@ -112,16 +112,12 @@ def cross_entropy(input, target):
         let our_loss = cross_entropy(input_var.as_tensor().clone(), target_gpu)?;
 
         // Compute gradients
-        let mut grads = our_loss.backward()?;
-        grads.resolve(device.try_gpu()?)?;
-        let our_grad = grads
-            .get(input_var.as_tensor())
-            .unwrap()
-            .clone()
-            .resolve()?;
+        let grads = our_loss.backward()?;
+        device.try_gpu()?.mark_step()?;
+        let our_grad = grads.get(input_var.as_tensor()).unwrap().clone();
 
         // Compare results
-        let our_loss_cpu = our_loss.resolve()?.to(&Device::CPU)?;
+        let our_loss_cpu = our_loss.to(&Device::CPU)?;
         let our_grad_cpu = our_grad.to(&Device::CPU)?;
         let ground_grad = ground_grad.to(&Device::CPU)?;
         let ground_loss = ground_loss.to(&Device::CPU)?;

--- a/crates/ratchet-nn/src/loss.rs
+++ b/crates/ratchet-nn/src/loss.rs
@@ -34,7 +34,7 @@ pub fn cross_entropy(inp: Tensor, target: Tensor) -> anyhow::Result<Tensor> {
     nll(inp, target)
 }
 
-#[cfg(all(test))]
+#[cfg(all(test, feature = "pyo3"))]
 mod tests {
     use super::*;
     use anyhow::Result;

--- a/crates/ratchet-nn/src/norm.rs
+++ b/crates/ratchet-nn/src/norm.rs
@@ -291,7 +291,7 @@ def layer_norm_backward(x, weight, bias = None):
             eps,
             remove_mean: true,
         };
-        let result_gpu = layer_norm_gpu.schedule(x_gpu)?.resolve()?;
+        let result_gpu = layer_norm_gpu.schedule(x_gpu)?;
 
         let ours = result_gpu.to(&Device::CPU)?;
         ground.all_close(&ours, 1e-4, 1e-4)?;
@@ -334,8 +334,8 @@ def layer_norm_backward(x, weight, bias = None):
 
         let result_gpu = layer_norm.schedule(x_var.as_tensor().clone())?;
 
-        let mut grads = result_gpu.backward()?;
-        grads.resolve(device.try_gpu()?)?;
+        let grads = result_gpu.backward()?;
+        device.try_gpu()?.mark_step()?;
 
         let x_grad = grads.get(&x_var.as_tensor()).unwrap().to(&Device::CPU)?;
         let weight_grad = grads.get(weight).unwrap().to(&Device::CPU)?;

--- a/crates/ratchet-nn/src/optim.rs
+++ b/crates/ratchet-nn/src/optim.rs
@@ -2,7 +2,7 @@
 use async_trait::async_trait;
 use half::{bf16, f16};
 use maybe_async::maybe_async;
-use ratchet::{DType, GradStore, Var, WgpuDevice};
+use ratchet::{DType, Device, GradStore, Var};
 
 #[maybe_async(AFIT)]
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait)]
@@ -11,7 +11,7 @@ pub trait Optimizer: Sized {
 
     fn new(vars: Vec<(Option<String>, Var)>, config: Self::Config) -> anyhow::Result<Self>;
 
-    async fn step(&mut self, grads: &ratchet::GradStore) -> anyhow::Result<()>;
+    async fn step(&mut self, grads: &ratchet::GradStore, device: &Device) -> anyhow::Result<()>;
 
     fn learning_rate(&self) -> f64;
 
@@ -24,10 +24,9 @@ pub trait Optimizer: Sized {
     async fn backward_step(
         &mut self,
         grads: &mut GradStore,
-        device: &WgpuDevice,
+        device: &Device,
     ) -> anyhow::Result<()> {
-        grads.resolve(device).unwrap();
-        self.step(grads).await
+        self.step(grads, device).await
     }
 
     fn from_slice(vars: &[&Var], config: Self::Config) -> anyhow::Result<Self> {
@@ -123,7 +122,7 @@ impl Optimizer for AdamW {
         self.params.lr = lr
     }
 
-    async fn step(&mut self, grads: &ratchet::GradStore) -> anyhow::Result<()> {
+    async fn step(&mut self, grads: &ratchet::GradStore, device: &Device) -> anyhow::Result<()> {
         self.step_t += 1;
         let lr = self.params.lr;
         let lambda = self.params.weight_decay;
@@ -132,20 +131,22 @@ impl Optimizer for AdamW {
         let beta2 = self.params.beta2;
         let scale_m = 1f64 / (1f64 - beta1.powi(self.step_t as i32));
         let scale_v = 1f64 / (1f64 - beta2.powi(self.step_t as i32));
+
+        // This makes sure we keep references to the copy tensors.
+        let mut updates = Vec::new();
+
         for var in self.vars.iter_mut() {
             let theta = &var.var;
             let m = &var.first_moment;
             let v = &var.second_moment;
-            let grad = grads.get(theta.as_tensor());
 
             // println!("Optimizer stepping: {:?}", var.label);
             // println!("Theta op: {:?}", theta.as_tensor().op());
             // println!("Theta id: {:?}", theta.as_tensor().id());
 
-            if let Some(g) = grad {
+            if let Some(g) = grads.get(theta.as_tensor()) {
                 let next_m = ((m.as_tensor().clone() * beta1 as f32)?
                     + (g.clone() * (1.0 - beta1 as f32))?)?;
-                // let next_m = (m.as_tensor().clone() * beta1 as f32)?;
                 let next_v = ((v.as_tensor().clone() * beta2 as f32)?
                     + (g.clone().square()? * (1.0 - beta2 as f32))?)?;
                 let m_hat = (next_m.clone() * scale_m as f32)?;
@@ -154,25 +155,16 @@ impl Optimizer for AdamW {
                 let adjusted_grad = (m_hat / (v_hat.sqrt()? + self.params.eps as f32)?)?;
                 let next_theta = (next_theta - (adjusted_grad.clone() * lr as f32)?)?;
 
-                #[cfg(feature = "debug")]
-                let next_m = next_m.resolve_debug()?;
-                #[cfg(feature = "debug")]
-                let next_v = next_v.resolve_debug()?;
-                #[cfg(feature = "debug")]
-                let next_theta = next_theta.resolve_debug()?;
-
-                #[cfg(not(feature = "debug"))]
-                let next_m = next_m.resolve_deferred()?;
-                #[cfg(not(feature = "debug"))]
-                let next_v = next_v.resolve_deferred()?;
-                #[cfg(not(feature = "debug"))]
-                let next_theta = next_theta.resolve_deferred()?;
-
-                theta.set(next_theta.clone())?;
-                m.set(next_m.clone())?;
-                v.set(next_v.clone())?;
+                // This ensures we keep references to the copy tensors.
+                updates.push((theta.set(next_theta), m.set(next_m), v.set(next_v)));
             }
         }
+
+        // Finalize all the tensors we just built above.
+        if let Ok(gpu) = device.try_gpu() {
+            gpu.mark_step()?;
+        }
+
         Ok(())
     }
 }

--- a/crates/ratchet-nn/src/var_map.rs
+++ b/crates/ratchet-nn/src/var_map.rs
@@ -191,7 +191,7 @@ impl VarMap {
             //     }
             // }
             Some(var) => {
-                if let Err(err) = var.set(value.clone()) {
+                if let Err(err) = var.set_sync(value.clone()) {
                     panic!("error setting {name}: {err}")
                 }
             }
@@ -219,7 +219,7 @@ impl VarMap {
                 //     }
                 // }
                 Some(var) => {
-                    if let Err(err) = var.set(value.as_ref().clone()) {
+                    if let Err(err) = var.set_sync(value.as_ref().clone()) {
                         panic!("error setting {name}: {err}")
                     }
                 }

--- a/crates/ratchet-nn/src/var_map.rs
+++ b/crates/ratchet-nn/src/var_map.rs
@@ -154,12 +154,7 @@ impl VarMap {
             let t = var.as_tensor().clone();
             let data_ref = Arc::clone(&data);
             futures.push(future_to_promise(async move {
-                let t_cpu = t
-                    .resolve_deferred()
-                    .unwrap()
-                    .to(&Device::CPU)
-                    .await
-                    .unwrap();
+                let t_cpu = t.to(&Device::CPU).await.unwrap();
                 data_ref.lock().unwrap().push((k, t_cpu));
                 Ok(JsValue::undefined())
             }));

--- a/crates/ratchet-nn/tests/optim.rs
+++ b/crates/ratchet-nn/tests/optim.rs
@@ -3,14 +3,144 @@ use ratchet::{
     test_utils::{to_vec0_round, to_vec1_round},
     Device, DeviceRequest, Tensor, Var,
 };
-use ratchet_nn::{AdamW, Linear, Module, Optimizer, ParamsAdamW};
+use ratchet_nn::{AdamW, Linear, Module, Optimizer, ParamsAdamW, SGD};
 
-#[test]
-fn adamw_linear_regression() -> anyhow::Result<()> {
+type OptimizerFactory<O> = fn(Vec<(Option<String>, Var)>) -> anyhow::Result<O>;
+
+fn run_linear_regression<O: Optimizer>(optimizer: OptimizerFactory<O>) -> anyhow::Result<()> {
+    let _ = env_logger::builder().is_test(true).try_init();
     let device = Device::request_device(DeviceRequest::GPU).unwrap();
     let w_gen = Tensor::from_data(vec![3f32, 1.], shape![1, 2], Device::CPU).to(&device)?;
     let b_gen = Tensor::from_data(vec![-2f32], shape![1, 1], Device::CPU).to(&device)?;
     let gen = Linear::new(w_gen, Some(b_gen));
+    let sample_xs = Tensor::from_data(
+        vec![2f32, 1., 7., 4., -4., 12., 5., 8.],
+        shape![4, 2],
+        Device::CPU,
+    );
+    let sample_xs = sample_xs.to(&device)?;
+    let sample_ys = gen.schedule(sample_xs.clone())?;
+
+    // Now use backprop to run a linear regression between samples and get the coefficients back.
+    let w = Var::zeros::<f32>(&shape![1, 2], &device);
+    let b = Var::zeros::<f32>(&shape![1, 1], &device);
+    let mut opt = optimizer(vec![
+        (Some(String::from("b")), b.clone()),
+        (Some(String::from("w")), w.clone()),
+    ])?;
+    let lin = Linear::new(w.as_tensor().clone(), Some(b.as_tensor().clone()));
+
+    for _step in 0..100 {
+        let ys = lin.schedule(sample_xs.clone())?;
+        let loss = ys.sub(sample_ys.clone())?.square()?.sum(&[0])?;
+        let mut grads = loss.backward()?;
+        opt.backward_step(&mut grads, &device)?;
+        // device.try_gpu().unwrap().mark_step().unwrap();
+        let b = b.as_tensor().to(&Device::CPU)?;
+        let w = w.as_tensor().to(&Device::CPU)?;
+        println!("b: {:?}, w: {:?}", b.to_vec::<f32>(), w.to_vec::<f32>());
+        let loss_cpu = loss.clone().to(&Device::CPU)?;
+        let loss_vec = loss_cpu.to_vec::<f32>()?;
+        println!("loss: {:?}", loss_vec[0]);
+    }
+
+    let b = b.as_tensor().to(&Device::CPU)?;
+    let w = w.as_tensor().to(&Device::CPU)?;
+    println!("b: {:?}, w: {:?}", b.to_vec::<f32>(), w.to_vec::<f32>());
+    assert_eq!(to_vec0_round(&b, 4)?, 0.7872);
+    assert_eq!(to_vec1_round(&w, 4)?, &[2.7257, 0.7097]);
+    Ok(())
+}
+
+#[test]
+fn sgd_linear_regression() -> anyhow::Result<()> {
+    fn optimizer(vars: Vec<(Option<String>, Var)>) -> anyhow::Result<SGD> {
+        SGD::new(vars, 0.001)
+    }
+    run_linear_regression(optimizer)
+}
+
+#[test]
+fn adamw_linear_regression() -> anyhow::Result<()> {
+    fn optimizer(vars: Vec<(Option<String>, Var)>) -> anyhow::Result<AdamW> {
+        let params = ParamsAdamW {
+            lr: 0.5,
+            ..Default::default()
+        };
+        AdamW::new(vars, params)
+    }
+    run_linear_regression(optimizer)
+}
+
+fn gradient_descent(optimizer: OptimizerFactory<impl Optimizer>) -> anyhow::Result<()> {
+    let _ = env_logger::builder().is_test(true).try_init();
+
+    let device = Device::request_device(DeviceRequest::GPU).unwrap();
+    let target = Tensor::from_data(vec![5.0], shape![1], Device::CPU).to(&device)?;
+
+    // Initialize variable at 0.0 (shape is scalar)
+    let w = Var::from_tensor(&Tensor::from_data(vec![0.0], shape![1], Device::CPU).to(&device)?)?;
+
+    let mut opt = optimizer(vec![(Some("w".into()), w.clone())])?;
+
+    for step in 0..100 {
+        // Compute loss = (w - target)^2
+        let loss = w.as_tensor().clone().sub(target.clone())?.square()?;
+
+        // Backpropagate
+        let mut grads = loss.backward()?;
+        opt.backward_step(&mut grads, &device)?;
+
+        // Print debug info
+        let current_w = w.as_tensor().to(&Device::CPU)?.to_vec::<f32>()?;
+        let current_loss = loss.to(&Device::CPU)?.to_vec::<f32>()?;
+        #[cfg(feature = "plotting")]
+        println!(
+            "Step {step}: w = {:.4}, loss = {:.4} (fmt: {})",
+            current_w[0],
+            current_loss[0],
+            w.as_tensor().to(&Device::CPU)?.plot_fmt()
+        );
+        println!(
+            "Step {step}: w = {:.4}, loss = {:.4}",
+            current_w[0], current_loss[0],
+        );
+    }
+
+    let final_w = w.as_tensor().to(&Device::CPU)?.to_vec::<f32>()?;
+    assert!(
+        (final_w[0] - target.to(&Device::CPU)?.to_vec::<f32>()?[0]).abs() < 0.1,
+        "Final w should be close to 5.0"
+    );
+    Ok(())
+}
+
+#[test]
+fn sgd_gradient_descent() -> anyhow::Result<()> {
+    fn optimizer(vars: Vec<(Option<String>, Var)>) -> anyhow::Result<SGD> {
+        SGD::new(vars, 0.1)
+    }
+    gradient_descent(optimizer)
+}
+
+#[test]
+fn adamw_gradient_descent() -> anyhow::Result<()> {
+    fn optimizer(vars: Vec<(Option<String>, Var)>) -> anyhow::Result<AdamW> {
+        let params = ParamsAdamW {
+            lr: 0.2,
+            ..Default::default()
+        };
+        AdamW::new(vars, params)
+    }
+    gradient_descent(optimizer)
+}
+
+#[test]
+fn test_intermediate() -> anyhow::Result<()> {
+    let device = Device::request_device(DeviceRequest::GPU).unwrap();
+    let w_gen = Tensor::from_data(vec![3f32, 1.], shape![1, 2], Device::CPU).to(&device)?;
+    let b_gen = Tensor::from_data(vec![-2f32], shape![1, 1], Device::CPU).to(&device)?;
+    let gen = Linear::new(w_gen.clone(), Some(b_gen.clone()));
     let sample_xs = Tensor::from_data(
         vec![2f32, 1., 7., 4., -4., 12., 5., 8.],
         shape![4, 2],
@@ -26,81 +156,22 @@ fn adamw_linear_regression() -> anyhow::Result<()> {
     // let b = Var::from_data(vec![0f32], shape![1], Device::CPU);
     let b =
         Var::from_tensor(&Tensor::from_data(vec![0f32], shape![1, 1], Device::CPU).to(&device)?)?;
-    let params = ParamsAdamW {
-        lr: 0.1,
-        ..Default::default()
-    };
-    let mut opt = AdamW::new(
-        vec![
-            (Some(String::from("b")), b.clone()),
-            (Some(String::from("w")), w.clone()),
-        ],
-        params,
-    )?;
-    let lin = Linear::new(w.as_tensor().clone(), Some(b.as_tensor().clone()));
-    for _step in 0..100 {
-        let ys = lin.schedule(sample_xs.clone())?;
-        let loss = ys.sub(sample_ys.clone())?.square()?.sum(&[0])?;
-        // ratchet::plot::render_to_file(&loss, "forward-pre-schedule.svg").unwrap();
-        let mut grads = loss.backward()?;
-        // ratchet::plot::render_to_file(&loss, "forward-post-schedule.svg").unwrap();
-        let loss_cpu = loss.clone().resolve()?.to(&Device::CPU)?;
-        let loss_vec = loss_cpu.to_vec::<f32>()?;
-        println!("loss: {:?}", loss_vec[0]);
-        let b = b.as_tensor().to(&Device::CPU)?;
-        let w = w.as_tensor().to(&Device::CPU)?;
-        println!("b: {:?}, w: {:?}", b.to_vec::<f32>(), w.to_vec::<f32>());
-        opt.backward_step(&mut grads, device.try_gpu()?)?;
-    }
-    let b = b.as_tensor().to(&Device::CPU)?;
-    let w = w.as_tensor().to(&Device::CPU)?;
-    println!("b: {:?}, w: {:?}", b.to_vec::<f32>(), w.to_vec::<f32>());
-    assert_eq!(to_vec0_round(&b, 4)?, 0.7872);
-    assert_eq!(to_vec1_round(&w, 4)?, &[2.7257, 0.7097]);
-    Ok(())
-}
-
-#[test]
-fn test_intermediate() -> anyhow::Result<()> {
-    let device = Device::request_device(DeviceRequest::GPU).unwrap();
-    let w_gen = Tensor::from_data(vec![3f32, 1.], shape![1, 2], Device::CPU).to(&device)?;
-    let b_gen = Tensor::from_data(vec![-2f32], shape![1, 1], Device::CPU).to(&device)?;
-    let gen = Linear::new(w_gen.clone(), Some(b_gen.clone()));
-    let sample_xs = Tensor::from_data(
-        vec![2f32, 1., 7., 4., -4., 12., 5., 8.],
-        shape![4, 2],
-        Device::CPU,
-    );
-    let sample_xs = sample_xs.to(&device)?;
-    let sample_ys = gen.schedule(sample_xs.clone())?.resolve()?;
-
-    // Now use backprop to run a linear regression between samples and get the coefficients back.
-    let w = Var::from_tensor(
-        &Tensor::from_data(vec![0f32, 0.], shape![1, 2], Device::CPU).to(&device)?,
-    )?;
-    // let b = Var::from_data(vec![0f32], shape![1], Device::CPU);
-    let b =
-        Var::from_tensor(&Tensor::from_data(vec![0f32], shape![1, 1], Device::CPU).to(&device)?)?;
     let lin = Linear::new(w.as_tensor().clone(), Some(b.as_tensor().clone()));
 
     let ys = lin.schedule(sample_xs.clone())?;
-    let loss = ys
-        .sub(sample_ys.clone())?
-        .square()?
-        // .sum_last_dim(0)?
-        .resolve()?;
+    let loss = ys.sub(sample_ys.clone())?.square()?;
 
     // Print loss
     println!("loss: {:?}", loss.to(&Device::CPU)?.to_vec::<f32>()?);
 
     let gen_grads = loss.backward()?;
     for (i, (_id, g)) in gen_grads.iter().enumerate() {
-        let g_clone = g.clone().resolve()?;
+        let g_clone = g.clone();
         println!(
             "gen_grads[{}]: (op {:?}) {:?}",
             i,
             g_clone.clone().op().name(),
-            g_clone.resolve()?.to(&Device::CPU)?.to_vec::<f32>()?
+            g_clone.to(&Device::CPU)?.to_vec::<f32>()?
         );
     }
     Ok(())


### PR DESCRIPTION
Main changes; all complementary:
- 8ff1fdd `Tensor::resolve` is replaced with a [LazyTensor](https://arxiv.org/abs/2102.13267) implementation. This includes caching the `Executable` with graph hash. Like LazyTensor, Tensors will now resolve either when their value is requested, or when `LazyGraphExecutor::mark_step` is called.
  - Additionally, this commit includes changes to `BufferAllocator` to adapt inplace assignments and shared object allocation to allow for many outputs.
- 1f4c299 Add an IR constraint to the `Operation` type, with `IrFields` macro. Its main job is hashing the compute graph for now; would love to extend to do compiling/simple fusion etc later.
- a5f5877 Extend CompiledOp to new `Compiled` with `::Copy` and `::Compute`. This lets us queue up `copy_buffer_to_buffer` commands as part of the same async wgpu queue, and works better with LazyTensor caching.