### PR TITLE
Workaround solution for inplace in backprop

### DIFF
--- a/crates/piston-core/src/gpu/buffer_allocator/lazy_graph_executor.rs
+++ b/crates/piston-core/src/gpu/buffer_allocator/lazy_graph_executor.rs
@@ -290,7 +290,9 @@ impl LazyGraphExecutor {
                             to_modify_src.requires_grad()
                         );
 
-                        if !self.inplace_support {
+                        if tensor.is_inplace() {
+                            true
+                        } else if !self.inplace_support {
                             // TODO(vinhowe): This really is horrible; we should be able to just
                             // check if the op supports inplace.
                             match tensor.op() {


### PR DESCRIPTION
There's an issue when dealing with inplace operations over multiple forward-backward passes, which is that the operations just bury the original operation under a bunch of ops that will be marked as resolved, prompting our backprop implementation to ignore them, keeping important variables from being updated.

The solution in this commit is to check, when constructing a forward pass, if the last inplace operation on a given outer tensor (with inner mutability, not OpTensor) is resolved, and if it is, go to the first non-inplace source of that operation (that is, what we'd get if we traversed backward until we got to the first non-inplace operation), and move the pointer of the outer tensor back to that source. This frees up the resolved inplace tensors and removes them from the subsequent graph.

An important note—a non-inplace operation could very well reference an inplace operation in a situation that looks like the following:

```
+----------------------------+   +--------------------+
| evaluated starting here ✅ |-->| out-of-place op ✅ |
+----------------------------+   +---------+----------+
                                           |
                                           v
            +-----------------+   +--------+--------+
            | inplace op 2 ❌ |-->| inplace op 1 ✅ |
            +-----------------+   +--------+--------+
                                           |
                                           v
                                 +---------+----------+
                                 | original source ✅ |
                                 +--------------------+
```

To address such scenarios, a better solution might be to "replay" all unresolved inplace operations on top of the original source, such that inplace op 2 directly references the original source. We'd have to play out a few scenarios to see if this makes more sense, and if the existing approach actually causes any bugs, especially with graph consistency/caching effectiveness.