### PR TITLE
New JS APIs: tensor, autodiff, nn

### DIFF
--- a/crates/piston-core/src/backprop.rs
+++ b/crates/piston-core/src/backprop.rs
@@ -777,11 +777,11 @@ impl OpTensor {
                         .clone()
                         .mul(grad.clone())?
                         .sum_keepdim(sum_axes.as_slice())?;
-                    accumulate_add(scale, grad_gamma)?;
+                    accumulate_add(scale, grad_gamma.squeeze_all()?)?;
 
                     if let Some(bias) = bias {
                         let grad_beta = grad.clone().sum_keepdim(sum_axes.as_slice())?;
-                        accumulate_add(bias, grad_beta)?;
+                        accumulate_add(bias, grad_beta.squeeze_all()?)?;
                     }
 
                     // Compute gradient w.r.t normalized input

--- a/crates/piston-core/src/backprop.rs
+++ b/crates/piston-core/src/backprop.rs
@@ -611,11 +611,10 @@ impl OpTensor {
                     input: arg,
                     op: UnaryOp::Relu,
                 }) => {
-                    let relu_grad = arg.clone().affine(2.0, 0.0)?.mul(
-                        arg.clone()
-                            .ge(arg.clone().zeros_like::<f32>(None, false)?)?
-                            .cast(arg.dtype())?,
-                    )?;
+                    let relu_grad = arg
+                        .clone()
+                        .ge(arg.clone().zeros_like::<f32>(None, false)?)?
+                        .cast(arg.dtype())?;
                     let arg_grad = grad.mul(relu_grad)?;
                     accumulate_add(arg, arg_grad)?;
                 }
@@ -623,10 +622,11 @@ impl OpTensor {
                     input: arg,
                     op: UnaryOp::Relu2,
                 }) => {
-                    let relu_grad = arg
-                        .clone()
-                        .ge(arg.clone().zeros_like::<f32>(None, false)?)?
-                        .cast(arg.dtype())?;
+                    let relu_grad = arg.clone().affine(2.0, 0.0)?.mul(
+                        arg.clone()
+                            .ge(arg.clone().zeros_like::<f32>(None, false)?)?
+                            .cast(arg.dtype())?,
+                    )?;
                     let arg_grad = grad.mul(relu_grad)?;
                     accumulate_add(arg, arg_grad)?;
                 }

--- a/crates/piston-core/src/ops/norm/mod.rs
+++ b/crates/piston-core/src/ops/norm/mod.rs
@@ -8,8 +8,8 @@ use piston_macros::WgslMetadata;
 use crate::{
     gpu::{dtype::WgslDType, BindGroupLayoutDescriptor},
     rvec, wgc, wgs, Array, BindingMode, BuiltIn, DType, GPUOperation, Kernel, KernelElement,
-    KernelRenderable, KernelSource, OpGuards, Operation, OperationError, RVec, Scalar, StorageView,
-    OpTensor, Vec2, Vec4, WgslKernelBuilder, WgslPrimitive, WorkgroupSize, Workload,
+    KernelRenderable, KernelSource, OpGuards, OpTensor, Operation, OperationError, RVec, Scalar,
+    StorageView, Vec2, Vec4, WgslKernelBuilder, WgslPrimitive, WorkgroupSize, Workload,
 };
 use derive_new::new;
 use inline_wgsl::wgsl;
@@ -447,7 +447,9 @@ def manual_rms_norm(input, scale):
         let scale = OpTensor::randn::<f32, _>(0., 1., N, Device::CPU, false)?;
 
         let bias = match var {
-            NormVariant::LayerNorm => Some(OpTensor::randn::<f32, _>(0., 1., N, Device::CPU, false)?),
+            NormVariant::LayerNorm => {
+                Some(OpTensor::randn::<f32, _>(0., 1., N, Device::CPU, false)?)
+            }
             NormVariant::RMSNorm => None,
         };
 

--- a/crates/piston-core/src/shape.rs
+++ b/crates/piston-core/src/shape.rs
@@ -131,7 +131,10 @@ impl Shape {
         self.0.drain(range)
     }
 
-    pub fn slice(&self, range: std::ops::Range<usize>) -> Self {
+    pub fn slice<R>(&self, range: R) -> Self
+    where
+        R: std::ops::RangeBounds<usize> + std::slice::SliceIndex<[usize], Output = [usize]>,
+    {
         Shape(self.0[range].to_vec().into())
     }
 

--- a/crates/piston-core/src/tensor.rs
+++ b/crates/piston-core/src/tensor.rs
@@ -3401,6 +3401,16 @@ impl Tensor {
     pub fn take_grad(&self) -> Option<Self> {
         self.inner_or_source().take_grad().map(Self::wrap)
     }
+
+    pub fn storage_id(&self) -> Option<usize> {
+        self.inner_or_source()
+            .storage()
+            .as_ref()
+            .and_then(|s| match s {
+                Storage::CPU(_) => None,
+                Storage::GPU(g) => Some(g.inner().global_id().inner() as _),
+            })
+    }
 }
 
 impl<T: TensorDType> From<ArrayD<T>> for Tensor {

--- a/crates/piston-macros/src/js_tensor.rs
+++ b/crates/piston-macros/src/js_tensor.rs
@@ -1,0 +1,666 @@
+// Slop
+use heck::ToLowerCamelCase;
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::{parse_macro_input, FnArg, ImplItem, ItemImpl, Pat, PatIdent, Type};
+
+/// Converts a string to lower camel case, preserving leading and trailing underscores.
+fn to_lower_camel_case_with_underscore(ident: &str) -> String {
+    let leading_count = ident.chars().take_while(|&c| c == '_').count();
+    let trailing_count = ident.chars().rev().take_while(|&c| c == '_').count();
+
+    if leading_count + trailing_count >= ident.len() {
+        // In the case that it's all underscores
+        return ident.to_string();
+    }
+
+    format!(
+        "{}{}{}",
+        &ident[..leading_count],
+        // Convert middle part to camel case
+        &ident[leading_count..ident.len() - trailing_count].to_lower_camel_case(),
+        &ident[ident.len() - trailing_count..]
+    )
+}
+
+pub fn js_tensor_operations(item: TokenStream) -> TokenStream {
+    // Parse the attribute arguments.
+    let mut item_impl = parse_macro_input!(item as ItemImpl);
+
+    // Extract the name of the struct being implemented (e.g., "JsTensor")
+    let js_struct_name = match &*item_impl.self_ty {
+        Type::Path(type_path) => type_path.path.segments.last().unwrap().ident.to_string(),
+        _ => panic!("Expected a path type for the self_ty"),
+    };
+
+    // Remove the "Js" prefix to get the underlying type (e.g., "Tensor")
+    let underlying_type = if let Some(underlying_type) = js_struct_name.strip_prefix("Js") {
+        underlying_type.to_string()
+    } else {
+        panic!("Expected a Js prefix for the self_ty");
+    };
+
+    // Create an identifier for the underlying type
+    let underlying_type_ident = syn::Ident::new(&underlying_type, proc_macro2::Span::call_site());
+
+    for impl_item in &mut item_impl.items {
+        if let ImplItem::Fn(ref mut input_fn) = impl_item {
+            // Look for our marker attribute #[js_tensor_operation].
+            let mut has_js_tensor_skip = false;
+            let is_async = input_fn.sig.asyncness.is_some();
+
+            // Remove the skip attribute.
+            input_fn.attrs.retain(|attr| {
+                if attr.path().is_ident("skip") {
+                    has_js_tensor_skip = true;
+                    false
+                } else {
+                    true
+                }
+            });
+
+            if has_js_tensor_skip {
+                continue;
+            }
+
+            let mut has_dtype_generic = false;
+            let mut has_shape_generic = false;
+
+            let mut specified_dtypes: Option<Vec<syn::Ident>> = None;
+            input_fn.attrs.retain(|attr| {
+                if attr.path().is_ident("dtype_generic") {
+                    has_dtype_generic = true;
+                    // Try to parse the tokens as a comma-separated list of idents.
+                    let dtypes = match attr.parse_args_with(
+                        syn::punctuated::Punctuated::<syn::Ident, syn::Token![,]>::parse_terminated,
+                    ) {
+                        Ok(parsed_dtypes) => Some(parsed_dtypes.into_iter().collect()),
+                        Err(_) => None,
+                    };
+                    specified_dtypes = dtypes;
+                    false
+                } else {
+                    true
+                }
+            });
+
+            // Determine the underlying core method name.
+            let method_name = input_fn.sig.ident.clone();
+            let js_method_name =
+                to_lower_camel_case_with_underscore(&input_fn.sig.ident.to_string());
+            input_fn
+                .attrs
+                .push(syn::parse_quote!(#[wasm_bindgen(js_name = #js_method_name)]));
+
+            // Process parameters (e.g. for setting js names).
+            for input in &mut input_fn.sig.inputs {
+                if let FnArg::Typed(pat_type) = input {
+                    if let syn::Pat::Ident(pat_ident) = &*pat_type.pat {
+                        let param_name = pat_ident.ident.to_string();
+                        let param_js_name = to_lower_camel_case_with_underscore(&param_name);
+                        if is_type(&pat_type.ty, "Shape")
+                            || is_type_ref(&pat_type.ty, "Shape")
+                            || is_type(&pat_type.ty, "ShapeWithOneHole")
+                            || is_type_ref(&pat_type.ty, "ShapeWithOneHole")
+                            || is_type(&pat_type.ty, "Dims")
+                            || is_optional_of_type(&pat_type.ty, "Shape")
+                            || is_optional_of_type(&pat_type.ty, "Dims")
+                        {
+                            let mut unchecked_param_type = if is_type(&pat_type.ty, "Dims")
+                                || is_optional_of_type(&pat_type.ty, "Dims")
+                            {
+                                "Int32Array | number[] | number".to_string()
+                            } else if is_type(&pat_type.ty, "ShapeWithOneHole")
+                                || is_optional_of_type(&pat_type.ty, "ShapeWithOneHole")
+                            {
+                                "Int32Array | number[]".to_string()
+                            } else {
+                                "Uint32Array | number[]".to_string()
+                            };
+                            if is_type(&pat_type.ty, "Shape")
+                                || is_type_ref(&pat_type.ty, "Shape")
+                                || is_type(&pat_type.ty, "ShapeWithOneHole")
+                                || is_type_ref(&pat_type.ty, "ShapeWithOneHole")
+                            {
+                                has_shape_generic = true;
+                            }
+                            if is_optional(&pat_type.ty) {
+                                unchecked_param_type =
+                                    format!("{} | null | undefined", unchecked_param_type);
+                            }
+                            pat_type
+                                .attrs
+                                // We do this because we technically accept both and we want to make that clear to typescript
+                                .push(syn::parse_quote!(
+                                    #[wasm_bindgen(js_name = #param_js_name, unchecked_param_type = #unchecked_param_type)]
+                                ));
+                        } else {
+                            pat_type
+                                .attrs
+                                .push(syn::parse_quote!(#[wasm_bindgen(js_name = #param_js_name)]));
+                        }
+                    }
+                }
+            }
+
+            // Generate conversion code for each parameter.
+            let mut prelude_stmts = Vec::new();
+            let mut call_args = Vec::new();
+            let mut has_self_param = false;
+            let mut to_dtype_cast_params = Vec::new();
+
+            // Iterate over each argument in the function signature.
+            // We'll store parameters that should be retained
+            let mut retained_inputs = Vec::new();
+
+            for input in &mut input_fn.sig.inputs {
+                match input {
+                    FnArg::Receiver(_) => {
+                        has_self_param = true;
+                        retained_inputs.push(input.clone());
+                    }
+                    FnArg::Typed(ref mut pat_type) => {
+                        let pat = &*pat_type.pat;
+                        let ty = &*pat_type.ty;
+                        let mut is_dtype_param = false;
+                        let is_reference = matches!(ty, Type::Reference(_));
+                        let new_ident = if let Pat::Ident(PatIdent { ref ident, .. }) = pat {
+                            // Check if this parameter is named "dtype"
+                            if ident == "dtype" {
+                                is_dtype_param = true;
+                            }
+                            syn::Ident::new(&ident.to_string(), ident.span())
+                        } else {
+                            syn::Ident::new("unknown", proc_macro2::Span::call_site())
+                        };
+                        to_dtype_cast_params.push(
+                            is_type(ty, "f32")
+                                || is_type(ty, "f16")
+                                || is_type(ty, "i32")
+                                || is_type(ty, "u32"),
+                        );
+
+                        let ident = quote! { #pat };
+                        // let (new_type, prelude_type, call_expr, conversion, _is_ref) =
+                        let TypeConversion {
+                            signature_type: new_type,
+                            prelude_type,
+                            call_expr,
+                            inner_conversion,
+                            is_ref: _,
+                            is_result: _,
+                        } = generate_type_and_conversion(
+                            ident.clone(),
+                            ident,
+                            ty,
+                            None,
+                            has_self_param,
+                        );
+                        if let Some(conv) = inner_conversion {
+                            prelude_stmts.push(quote! {
+                                let #new_ident: #prelude_type = #conv;
+                            });
+                        }
+                        *pat_type.ty = new_type;
+                        let ref_expr = if is_reference {
+                            quote! { & }
+                        } else {
+                            quote! {}
+                        };
+                        if !(has_dtype_generic && is_dtype_param) {
+                            call_args.push(quote! { #ref_expr #call_expr });
+                        }
+                        // Keep non-device parameters
+                        retained_inputs.push(input.clone());
+                    }
+                }
+            }
+
+            // Replace the function inputs with the filtered list (no device param)
+            input_fn.sig.inputs = syn::punctuated::Punctuated::from_iter(retained_inputs);
+
+            let inner_call = if has_self_param {
+                quote! { self.inner.clone().#method_name }
+            } else {
+                quote! { #underlying_type_ident::#method_name }
+            };
+
+            let result_call = if is_async {
+                quote! {
+                    .await.map_err(|e| e.to_string())?
+                }
+            } else {
+                quote! { .map_err(|e| e.to_string())? }
+            };
+
+            let gen_body = if input_fn.block.stmts.is_empty() {
+                if has_dtype_generic {
+                    // Special handling for methods with dtype parameter.
+                    let f32_args = call_args
+                        .iter()
+                        .zip(&to_dtype_cast_params)
+                        .map(|(arg, &needs_cast)| {
+                            if needs_cast {
+                                quote! { #arg as f32 }
+                            } else {
+                                quote! { #arg }
+                            }
+                        })
+                        .collect::<Vec<_>>();
+                    let f16_args = call_args
+                        .iter()
+                        .zip(&to_dtype_cast_params)
+                        .map(|(arg, &needs_cast)| {
+                            if needs_cast {
+                                quote! { f16::from_f32(#arg) }
+                            } else {
+                                quote! { #arg }
+                            }
+                        })
+                        .collect::<Vec<_>>();
+                    let i32_args = call_args
+                        .iter()
+                        .zip(&to_dtype_cast_params)
+                        .map(|(arg, &needs_cast)| {
+                            if needs_cast {
+                                quote! { #arg as i32 }
+                            } else {
+                                quote! { #arg }
+                            }
+                        })
+                        .collect::<Vec<_>>();
+                    let u32_args = call_args
+                        .iter()
+                        .zip(&to_dtype_cast_params)
+                        .map(|(arg, &needs_cast)| {
+                            if needs_cast {
+                                quote! { #arg as u32 }
+                            } else {
+                                quote! { #arg }
+                            }
+                        })
+                        .collect::<Vec<_>>();
+
+                    let mut arms = Vec::new();
+
+                    let includes_f32 = specified_dtypes
+                        .as_ref()
+                        .is_none_or(|ds| ds.iter().any(|dt| dt == "f32"));
+                    let includes_f16 = specified_dtypes
+                        .as_ref()
+                        .is_none_or(|ds| ds.iter().any(|dt| dt == "f16"));
+                    let includes_i32 = specified_dtypes
+                        .as_ref()
+                        .is_none_or(|ds| ds.iter().any(|dt| dt == "i32"));
+                    let includes_u32 = specified_dtypes
+                        .as_ref()
+                        .is_none_or(|ds| ds.iter().any(|dt| dt == "u32"));
+
+                    let shape_generic_part = if has_shape_generic {
+                        quote! { , _ }
+                    } else {
+                        quote! {}
+                    };
+
+                    if includes_f32 {
+                        arms.push(quote! {
+                            DType::F32 => #inner_call::<f32 #shape_generic_part>( #(#f32_args),* ),
+                        });
+                    }
+                    if includes_f16 {
+                        arms.push(quote! {
+                            DType::F16 => #inner_call::<f16 #shape_generic_part>( #(#f16_args),* ),
+                        });
+                    }
+                    if includes_i32 {
+                        arms.push(quote! {
+                            DType::I32 => #inner_call::<i32 #shape_generic_part>( #(#i32_args),* ),
+                        });
+                    }
+                    if includes_u32 {
+                        arms.push(quote! {
+                            DType::U32 => #inner_call::<u32 #shape_generic_part>( #(#u32_args),* ),
+                        });
+                    }
+
+                    quote! {
+                        {
+                            #(#prelude_stmts)*
+                            let result = (match dtype {
+                                #(#arms)*
+                                _ => return Err(JsValue::from_str("Unsupported dtype")),
+                            }) #result_call;
+                            Ok(Self { inner: result })
+                        }
+                    }
+                } else {
+                    // Standard handling for methods without a dtype parameter.
+                    quote! {
+                        {
+                            #(#prelude_stmts)*
+                            let result = #inner_call( #(#call_args),* )
+                                #result_call;
+                            Ok(Self { inner: result })
+                        }
+                    }
+                }
+            } else {
+                let user_block = &input_fn.block;
+                quote! {
+                    {
+                        #(#prelude_stmts)*
+                        #user_block
+                    }
+                }
+            };
+
+            // Replace the original (empty) function body with the generated one.
+            input_fn.block = syn::parse2(gen_body).expect("Failed to parse generated body");
+        }
+    }
+
+    TokenStream::from(quote! {
+        #item_impl
+    })
+}
+
+struct TypeConversion {
+    signature_type: Type,
+    prelude_type: proc_macro2::TokenStream,
+    call_expr: proc_macro2::TokenStream,
+    inner_conversion: Option<proc_macro2::TokenStream>,
+    is_ref: bool,
+    is_result: bool,
+}
+
+impl TypeConversion {
+    fn new(
+        signature_type: Type,
+        prelude_type: proc_macro2::TokenStream,
+        call_expr: proc_macro2::TokenStream,
+        inner_conversion: Option<proc_macro2::TokenStream>,
+        is_ref: bool,
+        is_result: bool,
+    ) -> Self {
+        Self {
+            signature_type,
+            prelude_type,
+            call_expr,
+            inner_conversion,
+            is_ref,
+            is_result,
+        }
+    }
+}
+
+/// Recursively generate conversion code for a given expression and type.
+/// Third return value is whether the outer type should become a reference.
+fn generate_type_and_conversion(
+    expr: proc_macro2::TokenStream,
+    ident: proc_macro2::TokenStream,
+    ty: &Type,
+    outer_ty: Option<&Type>,
+    has_self: bool,
+) -> TypeConversion {
+    if is_type(ty, "Tensor") {
+        TypeConversion::new(
+            syn::parse_quote!(JsTensor),
+            quote! { #ty },
+            ident,
+            Some(quote! { #expr.inner }),
+            false,
+            false,
+        )
+    } else if is_type(ty, "Parameter") {
+        TypeConversion::new(
+            syn::parse_quote!(JsParameter),
+            quote! { #ty },
+            ident,
+            Some(quote! { #expr.inner }),
+            false,
+            false,
+        )
+    } else if is_type(ty, "Shape") {
+        TypeConversion::new(
+            syn::parse_quote!(Vec<usize>),
+            quote! { #ty },
+            ident,
+            Some(quote! { Shape::from(#expr) }),
+            false,
+            false,
+        )
+    } else if is_type_ref(ty, "Shape") {
+        TypeConversion::new(
+            syn::parse_quote!(Vec<usize>),
+            quote! { #ty },
+            ident,
+            Some(quote! { &Shape::from(#expr) }),
+            true,
+            false,
+        )
+    } else if is_type(ty, "ShapeWithOneHole") {
+        let is_option = if let Some(outer_ty) = outer_ty {
+            is_type(outer_ty, "Option")
+        } else {
+            false
+        };
+        let result_expr = if is_option {
+            quote! {?}
+        } else {
+            quote! {?.ok_or(JsValue::from_str("Missing required dims"))?}
+        };
+        TypeConversion::new(
+            syn::parse_quote!(JsValue),
+            quote! { FromJsVecISize },
+            ident,
+            Some(quote! { FromJsVecISize::from_js_value(#expr) #result_expr }),
+            false,
+            true,
+        )
+    } else if is_type(ty, "Dim") {
+        TypeConversion::new(
+            syn::parse_quote!(isize),
+            quote! { FromJsDim },
+            ident,
+            Some(quote! { FromJsDim(#expr) }),
+            true,
+            false,
+        )
+    } else if is_type(ty, "Dims") {
+        let is_option = if let Some(outer_ty) = outer_ty {
+            is_type(outer_ty, "Option")
+        } else {
+            false
+        };
+        let result_expr = if is_option {
+            quote! {?}
+        } else {
+            quote! {?.ok_or(JsValue::from_str("Missing required dims"))?}
+        };
+        TypeConversion::new(
+            syn::parse_quote!(JsValue),
+            quote! { FromJsVecISize },
+            ident,
+            Some(quote! { FromJsVecISize::from_js_value(#expr) #result_expr }),
+            false,
+            true,
+        )
+    } else if is_type(ty, "DType") {
+        TypeConversion::new(
+            syn::parse_quote!(Option<JsDType>),
+            quote! { #ty },
+            ident,
+            if has_self {
+                Some(quote! { #expr.map(|d| d.dtype).unwrap_or(self.inner.dtype()) })
+            } else {
+                Some(quote! { #expr.map(|d| d.dtype).unwrap_or(DType::F32) })
+            },
+            false,
+            false,
+        )
+    } else if is_type(ty, "Device") || is_type_ref(ty, "Device") {
+        let is_option = if let Some(outer_ty) = outer_ty {
+            is_type(outer_ty, "Option")
+        } else {
+            false
+        };
+
+        let is_ref = is_type_ref(ty, "Device");
+        let ref_expr = if is_ref && !is_option {
+            quote! { & }
+        } else {
+            quote! {}
+        };
+
+        let (inner_expr, unwrap_or_expr) = if is_option {
+            (quote! {#expr.inner.clone()}, quote! {})
+        } else {
+            (
+                quote! {#expr.map(|d| d.inner)},
+                if has_self {
+                    quote! { .unwrap_or(self.inner.device()) }
+                } else {
+                    quote! { .unwrap_or(gpu_sync()?.inner.clone()) }
+                },
+            )
+        };
+
+        let (ident_expr, prelude_type) = if is_ref && is_option {
+            (quote! { #ident.as_ref() }, quote! { Device })
+        } else {
+            (quote! { #ident }, quote! { #ty })
+        };
+
+        TypeConversion::new(
+            if is_option {
+                syn::parse_quote!(JsDevice)
+            } else {
+                syn::parse_quote!(Option<JsDevice>)
+            },
+            prelude_type,
+            ident_expr,
+            Some(quote! { #ref_expr #inner_expr #unwrap_or_expr }),
+            is_ref,
+            false,
+        )
+    } else if let Some((inner_ty, outer_ty)) = get_inner_type(ty, "Option") {
+        // let (new_inner_type, prelude_type, ident, inner_conversion, is_ref) =
+        //     generate_type_and_conversion(quote! { x }, ident, inner_ty, Some(outer_ty), has_self);
+        let TypeConversion {
+            signature_type,
+            prelude_type,
+            call_expr,
+            inner_conversion,
+            is_ref: _,
+            is_result,
+        } = generate_type_and_conversion(
+            ident.clone(),
+            ident.clone(),
+            inner_ty,
+            Some(outer_ty),
+            has_self,
+        );
+        let result_expr = if is_result {
+            quote! { .transpose()? }
+        } else {
+            quote! {}
+        };
+        let (signature_type, inner_conversion) = if is_type(&signature_type, "JsValue") {
+            // We can't wrap JsValue in an Option for whatever reason.
+            (signature_type, inner_conversion)
+        } else {
+            (
+                syn::parse_quote!(Option<#signature_type>),
+                inner_conversion.map(|c| quote! { #expr.map(|#ident| { #c }) #result_expr  }),
+            )
+        };
+        TypeConversion::new(
+            signature_type,
+            quote! { Option<#prelude_type> },
+            call_expr,
+            inner_conversion,
+            false,
+            false,
+        )
+    } else if let Some((inner_ty, outer_ty)) = get_inner_type(ty, "RVec") {
+        // let (new_inner_type, prelude_type, ident, inner_conversion, _is_ref) =
+        //     generate_type_and_conversion(quote! { x }, ident, inner_ty, Some(outer_ty), has_self);
+        let TypeConversion {
+            signature_type: new_inner_type,
+            prelude_type,
+            call_expr: ident,
+            inner_conversion,
+            is_ref: _,
+            is_result: _,
+        } = generate_type_and_conversion(quote! { x }, ident, inner_ty, Some(outer_ty), has_self);
+        let new_type = syn::parse_quote!(Vec<#new_inner_type>);
+        TypeConversion::new(
+            new_type,
+            quote! { RVec<#prelude_type> },
+            ident,
+            inner_conversion
+                .map(|c| quote! { #expr.into_iter().map(|x| { #c }).collect() })
+                .or(Some(quote! { #expr.into_iter().collect() })),
+            false,
+            false,
+        )
+    } else {
+        TypeConversion::new(ty.clone(), quote! { #ty }, ident, None, false, false)
+    }
+}
+
+/// Helper: if the type is a container (e.g. Option or Vec), return its inner type.
+fn get_inner_type<'a>(ty: &'a Type, container: &str) -> Option<(&'a Type, &'a Type)> {
+    if let Type::Path(type_path) = ty {
+        if let Some(segment) = type_path.path.segments.first() {
+            if segment.ident == container {
+                if let syn::PathArguments::AngleBracketed(angle_bracketed) = &segment.arguments {
+                    if let Some(syn::GenericArgument::Type(inner_ty)) = angle_bracketed.args.first()
+                    {
+                        return Some((inner_ty, ty));
+                    }
+                }
+            }
+        }
+    }
+    None
+}
+
+/// Helper: checks whether a type is exactly the given expected type (e.g. "JsTensor").
+fn is_type(ty: &Type, expected: &str) -> bool {
+    if let Type::Path(type_path) = ty {
+        if type_path.qself.is_none() && type_path.path.segments.len() == 1 {
+            return type_path.path.segments[0].ident == expected;
+        }
+    }
+    false
+}
+
+/// Helper: checks whether a type is an Option of the expected type (e.g. "Option<Tensor>").
+fn is_optional_of_type(ty: &Type, expected: &str) -> bool {
+    if let Some((Type::Path(type_path), _)) = get_inner_type(ty, "Option") {
+        if type_path.qself.is_none() && type_path.path.segments.len() == 1 {
+            return type_path.path.segments[0].ident == expected;
+        }
+    }
+    false
+}
+
+fn is_optional(ty: &Type) -> bool {
+    if let Some((_, _)) = get_inner_type(ty, "Option") {
+        return true;
+    }
+    false
+}
+
+/// Helper: checks whether a type is a reference to the expected type (e.g. "&Shape").
+fn is_type_ref(ty: &Type, expected: &str) -> bool {
+    if let Type::Reference(type_ref) = ty {
+        if let Type::Path(type_path) = &*type_ref.elem {
+            if type_path.qself.is_none() && type_path.path.segments.len() == 1 {
+                return type_path.path.segments[0].ident == expected;
+            }
+        }
+    }
+    false
+}

--- a/crates/piston-macros/src/lib.rs
+++ b/crates/piston-macros/src/lib.rs
@@ -1,4 +1,5 @@
 mod ir_fields;
+mod js_tensor;
 mod scoped_module;
 mod wgsl_metadata;
 
@@ -29,4 +30,12 @@ pub fn derive_ir_fields(input: TokenStream) -> TokenStream {
 #[proc_macro_attribute]
 pub fn scoped_module(_attr: TokenStream, item: TokenStream) -> TokenStream {
     scoped_module::scoped_module(item)
+}
+
+/// Derives the `JsTensorMethod` trait implementation for a method.
+///
+/// Automatically does the boilerplate for converting a method to a JS method.
+#[proc_macro_attribute]
+pub fn js_tensor_operations(_attr: TokenStream, item: TokenStream) -> TokenStream {
+    js_tensor::js_tensor_operations(item)
 }

--- a/crates/piston-web/Cargo.toml
+++ b/crates/piston-web/Cargo.toml
@@ -32,8 +32,12 @@ wasm-opt = [
 piston-models = { path = "../piston-models" }
 piston-nn = { path = "../piston-nn" }
 piston-datasets = { path = "../piston-datasets" }
+piston-macros = { path = "../piston-macros" }
 piston = { path = "../piston-core" }
+half = { workspace = true }
+wgpu = { workspace = true }
 wasm-bindgen = { workspace = true }
+safetensors = { workspace = true }
 wasm-bindgen-futures = { workspace = true }
 js-sys = { workspace = true }
 thiserror.workspace = true
@@ -51,6 +55,7 @@ tokenizers = { version = "0.19.1", default-features = false, features = [
 ] }
 futures = "0.3.30"
 async-trait = { workspace = true }
+paste = { workspace = true }
 [dependencies.web-sys]
 features = ['console', 'Window', 'Navigator']
 workspace = true

--- a/crates/piston-web/cast.js
+++ b/crates/piston-web/cast.js
@@ -1,0 +1,5 @@
+// We use this to cast JsValue to the correct type in rustland. I'm still not 
+// sure I understand why we need this, but it does work.
+export const cast = (value) => {
+  return value;
+};

--- a/crates/piston-web/src/device.rs
+++ b/crates/piston-web/src/device.rs
@@ -1,0 +1,83 @@
+use std::cell::RefCell;
+
+use piston::{Device, DeviceRequest};
+use wasm_bindgen::prelude::*;
+
+#[wasm_bindgen(js_name = Device)]
+#[derive(Clone)]
+pub struct JsDevice {
+    #[wasm_bindgen(skip)]
+    pub(crate) inner: Device,
+}
+
+#[wasm_bindgen(js_class = Device)]
+impl JsDevice {
+    // This is used so we can keep a global device instance in the js lib without it being moved
+    // into various methods. Probably not the best way to do this.
+    #[wasm_bindgen(js_name = _clone)]
+    pub fn _clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+        }
+    }
+
+    #[wasm_bindgen(js_name = markStep)]
+    pub async fn mark_step(&self) -> Result<(), JsValue> {
+        self.inner
+            .try_gpu()
+            .unwrap()
+            .mark_step()
+            .await
+            .map_err(|e| e.to_string())?;
+        Ok(())
+    }
+}
+
+thread_local! {
+    pub static GPU_DEVICE: RefCell<Option<JsDevice>> = const { RefCell::new(None) };
+}
+
+pub async fn gpu() -> Result<JsDevice, JsValue> {
+    // First check if the device is already initialized
+    let maybe_device = GPU_DEVICE.with(|refcell| refcell.borrow().clone());
+
+    if let Some(device) = maybe_device {
+        return Ok(device);
+    }
+
+    // Otherwise, initialize it
+    let device = Device::request_device(DeviceRequest::GPU)
+        .await
+        .map_err(|e| e.to_string())?;
+
+    let js_device = JsDevice { inner: device };
+    GPU_DEVICE.with(|refcell| refcell.borrow_mut().replace(js_device.clone()));
+
+    Ok(js_device)
+}
+
+pub fn gpu_sync() -> Result<JsDevice, JsValue> {
+    GPU_DEVICE
+        .with(|refcell| refcell.borrow().clone())
+        .ok_or(JsValue::from_str("GPU device not initialized"))
+}
+
+pub async fn cpu() -> JsDevice {
+    JsDevice { inner: Device::CPU }
+}
+
+#[wasm_bindgen(js_name = gpu)]
+pub async fn gpu_wasm() -> Result<JsDevice, JsValue> {
+    gpu().await
+}
+
+#[wasm_bindgen(js_name = cpu)]
+pub async fn cpu_wasm() -> Result<JsDevice, JsValue> {
+    Ok(cpu().await)
+}
+
+#[wasm_bindgen]
+pub fn seed(seed: u64) -> Result<(), JsValue> {
+    gpu_sync()?.inner.set_seed(seed);
+    Ok(())
+}

--- a/crates/piston-web/src/dtype.rs
+++ b/crates/piston-web/src/dtype.rs
@@ -1,0 +1,51 @@
+use piston::DType;
+use wasm_bindgen::prelude::*;
+
+#[wasm_bindgen(js_name = DType)]
+pub struct JsDType {
+    #[wasm_bindgen(skip)]
+    pub(crate) dtype: DType,
+}
+
+#[wasm_bindgen(js_class = DType)]
+impl JsDType {
+    #[wasm_bindgen]
+    pub fn _clone(&self) -> JsDType {
+        JsDType { dtype: self.dtype }
+    }
+
+    #[wasm_bindgen(js_name = isFloatingPoint)]
+    pub fn is_floating_point(&self) -> bool {
+        self.dtype.is_float()
+    }
+
+    #[wasm_bindgen(js_name = isSigned)]
+    pub fn is_signed(&self) -> bool {
+        self.dtype.is_signed()
+    }
+
+    #[wasm_bindgen(js_name = itemsize)]
+    pub fn itemsize(&self) -> usize {
+        self.dtype.size_of()
+    }
+}
+
+#[wasm_bindgen(getter)]
+pub fn float32() -> JsDType {
+    JsDType { dtype: DType::F32 }
+}
+
+#[wasm_bindgen(getter)]
+pub fn float16() -> JsDType {
+    JsDType { dtype: DType::F16 }
+}
+
+#[wasm_bindgen(getter)]
+pub fn int32() -> JsDType {
+    JsDType { dtype: DType::I32 }
+}
+
+#[wasm_bindgen(getter)]
+pub fn uint32() -> JsDType {
+    JsDType { dtype: DType::U32 }
+}

--- a/crates/piston-web/src/lib.rs
+++ b/crates/piston-web/src/lib.rs
@@ -1,5 +1,11 @@
 #![cfg(target_arch = "wasm32")]
+mod device;
+mod dtype;
 mod model;
+mod serialization;
+mod shape;
+mod tensor;
+
 #[cfg(test)]
 mod test_utils;
 

--- a/crates/piston-web/src/serialization.rs
+++ b/crates/piston-web/src/serialization.rs
@@ -1,0 +1,100 @@
+use std::sync::Arc;
+
+use crate::tensor::JsTensor;
+use futures::lock::Mutex;
+use js_sys::{Object, Reflect};
+use piston::Device;
+use piston::OpTensor;
+use piston::Tensor;
+use wasm_bindgen::prelude::*;
+use wasm_bindgen::JsValue;
+use wasm_bindgen_futures::future_to_promise;
+use wasm_bindgen_futures::JsFuture;
+use web_sys::Blob;
+use web_sys::Url;
+
+/// Saves tensors to a safetensors format and returns a URL for download
+///
+/// The input is expected to be a JavaScript object mapping tensor ID strings to
+/// either JsTensor or JsParameter objects.
+#[wasm_bindgen]
+pub async fn save(data: JsValue) -> anyhow::Result<String, JsValue> {
+    // Check if the data is a JavaScript object
+    if !data.is_object() {
+        return Err(JsValue::from_str(
+            "Expected an object mapping tensor IDs to tensors or parameters",
+        ));
+    }
+
+    // Get object keys
+    let obj = Object::from(data);
+    let keys = js_sys::Object::keys(&obj);
+    let keys_len = keys.length();
+
+    let mut tensors: Vec<(String, Tensor)> = Vec::with_capacity(keys_len as usize);
+
+    for i in 0..keys_len {
+        let key = keys.get(i).as_string().unwrap();
+        let value = Reflect::get(&obj, &JsValue::from_str(&key))?;
+
+        // Try to extract tensor from the value
+        match JsTensor::try_from(value) {
+            Ok(tensor) => tensors.push((key, tensor.inner.clone())),
+            Err(e) => {
+                return Err(JsValue::from_str(&format!(
+                    "Error processing key '{}': {}",
+                    key,
+                    e.as_string().unwrap_or_else(|| "Unknown error".to_string())
+                )))
+            }
+        }
+    }
+
+    // Make sure we have at least one tensor
+    if tensors.is_empty() {
+        return Err(JsValue::from_str(
+            "No valid tensors found in the provided object",
+        ));
+    }
+
+    let data = Arc::new(Mutex::new(Vec::new()));
+    let mut futures = Vec::new();
+
+    // For each Var, move the Tensor to CPU asynchronously.
+    for (k, tensor) in tensors.iter() {
+        let k = k.clone();
+        let t = tensor.clone();
+        let data_ref = Arc::clone(&data);
+        futures.push(future_to_promise(async move {
+            let t_cpu = t.to(&Device::CPU).await.unwrap();
+            data_ref.lock().await.push((k, t_cpu));
+            Ok(JsValue::undefined())
+        }));
+    }
+
+    // Wait for all futures
+    let promise_array = js_sys::Array::from_iter(futures.iter());
+    JsFuture::from(js_sys::Promise::all(&promise_array)).await?;
+
+    // Collect the results
+    let data = Arc::try_unwrap(data).unwrap().into_inner();
+
+    // Convert to the format expected by safetensors
+    let data_ref: Vec<(&String, OpTensor)> = data
+        .iter()
+        .map(|(k, v)| (k, v.inner().read().clone()))
+        .collect::<Vec<_>>();
+
+    // Serialize to safetensors format
+    let serialized = safetensors::tensor::serialize(data_ref.iter().map(|(k, v)| (k, v)), &None)
+        .map_err(|e| JsValue::from_str(&format!("Failed to serialize tensors: {}", e)))?;
+
+    // Create a Uint8Array from the serialized data
+    let uint8_array = js_sys::Uint8Array::from(&serialized[..]);
+    let blob = Blob::new_with_u8_array_sequence(&js_sys::Array::of1(&JsValue::from(uint8_array)))?;
+
+    // Create a download URL
+    let url = Url::create_object_url_with_blob(&blob)?;
+
+    Ok(url)
+}

--- a/crates/piston-web/src/shape.rs
+++ b/crates/piston-web/src/shape.rs
@@ -1,0 +1,113 @@
+use piston::{Dim, Dims, RVec, Shape, ShapeWithOneHole, D};
+use wasm_bindgen::{JsCast, JsValue};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct FromJsDim(pub(crate) isize);
+
+impl Dim for FromJsDim {
+    fn to_index(&self, shape: &Shape, op: &'static str) -> anyhow::Result<usize> {
+        let dim = self.0;
+        let dim: Box<dyn Dim> = match dim {
+            dim if dim < 0 => Box::new(D::Minus(dim.unsigned_abs())),
+            _ => Box::new(dim as usize),
+        };
+        dim.to_index(shape, op)
+    }
+
+    fn to_index_plus_one(&self, shape: &piston::Shape, op: &'static str) -> anyhow::Result<usize> {
+        let dim = self.0;
+        let dim: Box<dyn Dim> = match dim {
+            dim if dim < 0 => Box::new(D::Minus(dim.unsigned_abs())),
+            _ => Box::new(dim as usize),
+        };
+        dim.to_index_plus_one(shape, op)
+    }
+}
+
+pub struct FromJsVecISize(pub(crate) Vec<isize>);
+
+impl Dims for FromJsVecISize {
+    fn to_indexes_internal(self, shape: &Shape, op: &'static str) -> anyhow::Result<RVec<usize>> {
+        let dims = self
+            .0
+            .iter()
+            .map(|d| FromJsDim(*d).to_index(shape, op))
+            .collect::<Result<RVec<_>, _>>()?;
+        Ok(dims)
+    }
+}
+
+impl FromJsVecISize {
+    // Create a function instead of implementing TryFrom for Option<FromJsDims>
+    pub fn from_js_value(value: JsValue) -> Result<Option<Self>, JsValue> {
+        if value.is_null() || value.is_undefined() {
+            return Ok(None);
+        }
+
+        if let Some(num) = value.as_f64() {
+            // If it's a single number
+            Ok(Some(FromJsVecISize(vec![num as isize])))
+        } else if value.is_array() {
+            // If it's a JavaScript array
+            let array = value.dyn_into::<js_sys::Array>().unwrap();
+            let dims = array
+                .iter()
+                .filter_map(|v| v.as_f64().map(|f| f as isize))
+                .collect::<Vec<_>>();
+            Ok(Some(FromJsVecISize(dims)))
+        } else if js_sys::Int32Array::instanceof(&value) {
+            // If it's an Int32Array
+            let array = js_sys::Int32Array::from(value);
+            let dims = array
+                .to_vec()
+                .into_iter()
+                .map(|v| v as isize)
+                .collect::<Vec<_>>();
+            Ok(Some(FromJsVecISize(dims)))
+        } else {
+            Err(JsValue::from_str("Expected a number, array, or Int32Array"))
+        }
+    }
+}
+
+impl ShapeWithOneHole for FromJsVecISize {
+    fn into_shape(self, el_count: usize) -> anyhow::Result<Shape> {
+        let mut hole_count = 0;
+        let mut hole_index = None;
+        let mut product = 1;
+
+        for (i, &dim) in self.0.iter().enumerate() {
+            if dim == -1 {
+                hole_count += 1;
+                hole_index = Some(i);
+                if hole_count > 1 {
+                    anyhow::bail!("at most one dimension can be -1");
+                }
+            } else if dim <= 0 {
+                anyhow::bail!("dimensions must be positive except for at most one -1");
+            } else {
+                product *= dim as usize;
+            }
+        }
+
+        let mut shape_vec = RVec::with_capacity(self.0.len());
+
+        if product == 0 {
+            anyhow::bail!("cannot reshape tensor of {el_count} elements with a product of 0");
+        }
+        if el_count % product != 0 {
+            anyhow::bail!("cannot reshape tensor with {el_count} elements to shape with -1");
+        }
+        let inferred_dim = el_count / product;
+
+        for (i, &dim) in self.0.iter().enumerate() {
+            if hole_index == Some(i) {
+                shape_vec.push(inferred_dim);
+            } else {
+                shape_vec.push(dim as usize);
+            }
+        }
+
+        Ok(Shape::from(shape_vec))
+    }
+}

--- a/crates/piston-web/src/tensor.rs
+++ b/crates/piston-web/src/tensor.rs
@@ -1,0 +1,886 @@
+use half::f16;
+use paste::paste;
+use piston::{DType, Device, Dim, IrScalarValue, IrValue, LazyOp, RVec, Shape, Tensor};
+use piston_macros::js_tensor_operations;
+use std::collections::HashMap;
+use wasm_bindgen::prelude::*;
+
+use crate::{
+    device::{gpu_sync, JsDevice, GPU_DEVICE},
+    dtype::JsDType,
+    shape::{FromJsDim, FromJsVecISize},
+};
+
+#[wasm_bindgen(js_name = Tensor)]
+pub struct JsTensor {
+    pub(crate) inner: Tensor,
+}
+
+type JsTensorResult = Result<JsTensor, JsValue>;
+
+#[wasm_bindgen(js_class = Tensor)]
+impl JsTensor {
+    pub fn id(&self) -> usize {
+        self.inner.id().0
+    }
+
+    // - Skipping storage_view
+
+    pub fn rank(&self) -> usize {
+        self.inner.rank()
+    }
+
+    pub fn dtype(&self) -> JsDType {
+        JsDType {
+            dtype: self.inner.dtype(),
+        }
+    }
+
+    #[wasm_bindgen(unchecked_return_type = "number[] | number")]
+    pub fn size(&self, dim: Option<isize>) -> JsValue {
+        if let Some(dim) = dim {
+            let dim = FromJsDim(dim);
+            let size = dim.to_index(&self.inner.shape(), "size").unwrap();
+            JsValue::from_f64(self.inner.shape()[size] as f64)
+        } else {
+            let shape = self.inner.shape().to_vec();
+            let array = js_sys::Array::new();
+            for dim in shape {
+                array.push(&JsValue::from_f64(dim as f64));
+            }
+            array.into()
+        }
+    }
+
+    pub fn shape(&self) -> Vec<usize> {
+        self.inner.shape().to_vec()
+    }
+
+    #[wasm_bindgen(unchecked_return_type = "number[] | number")]
+    pub fn stride(&self, dim: Option<isize>) -> JsValue {
+        if let Some(dim) = dim {
+            let dim = FromJsDim(dim);
+            let stride = dim.to_index(&self.inner.shape(), "stride").unwrap();
+            JsValue::from_f64(self.inner.stride()[stride] as f64)
+        } else {
+            let stride = self.inner.stride().to_vec();
+            let array = js_sys::Array::new();
+            for dim in stride {
+                array.push(&JsValue::from_f64(dim as f64));
+            }
+            array.into()
+        }
+    }
+
+    // - Skipping num_bytes
+
+    pub fn device(&self) -> String {
+        match self.inner.device() {
+            Device::CPU => "cpu".to_string(),
+            Device::GPU(_) => "webgpu".to_string(),
+        }
+    }
+
+    // - Skipping storage
+
+    pub fn resolved(&self) -> bool {
+        self.inner.resolved()
+    }
+
+    pub fn op(&self) -> JsValue {
+        let op = self.inner.op();
+        let ir = op.ir();
+        let name = ir.name().to_string();
+
+        let obj = js_sys::Object::new();
+        js_sys::Reflect::set(&obj, &"name".into(), &JsValue::from_str(&name)).unwrap();
+
+        if let Some(ir_fields) = ir.fields() {
+            js_sys::Reflect::set(
+                &obj,
+                &"fields".into(),
+                &convert_ir_fields_to_js(ir_fields, &op),
+            )
+            .unwrap();
+        }
+
+        obj.into()
+    }
+
+    // Convenient for building graphs
+    #[wasm_bindgen(js_name = srcIds)]
+    pub fn src_ids(&self) -> Vec<usize> {
+        self.inner.op().srcs().iter().map(|s| s.id().0).collect()
+    }
+
+    pub fn scope(&self) -> Option<String> {
+        self.inner.scope().clone()
+    }
+
+    #[wasm_bindgen(js_name = isScalar)]
+    pub fn is_scalar(&self) -> bool {
+        self.inner.is_scalar()
+    }
+
+    #[wasm_bindgen(js_name = requiresGrad)]
+    pub fn requires_grad(&self) -> bool {
+        self.inner.requires_grad()
+    }
+
+    #[wasm_bindgen(js_name = storageId)]
+    pub fn storage_id(&self) -> Option<usize> {
+        self.inner.storage_id()
+    }
+}
+
+macro_rules! impl_binary_op {
+    ($op:ident, $op_fn:expr) => {
+        #[wasm_bindgen(js_class = Tensor)]
+        #[js_tensor_operations]
+        impl JsTensor {
+            pub fn $op(
+                &self,
+                #[wasm_bindgen(unchecked_param_type = "Tensor | number")] other: JsValue,
+            ) -> JsTensorResult {
+                if let Ok(other) = JsTensor::try_from(other.clone()) {
+                    Ok(JsTensor {
+                        inner: self
+                            .inner
+                            .clone()
+                            .$op(other.inner)
+                            .map_err(|e| e.to_string())?,
+                    })
+                } else {
+                    let other: Option<f32> = other.as_f64().map(|f| f as f32);
+                    if let Some(other) = other {
+                        Ok(JsTensor {
+                            inner: ($op_fn)(self.inner.clone(), other)
+                                .map_err(|e| e.to_string())?,
+                        })
+                    } else {
+                        Err(JsValue::from_str(&format!(
+                            "{}: other must be a tensor or a number",
+                            stringify!($op)
+                        )))
+                    }
+                }
+            }
+        }
+    };
+}
+
+macro_rules! impl_binary_op_tensor {
+    ($op:ident) => {
+        paste! {
+            #[wasm_bindgen(js_class = Tensor)]
+            #[js_tensor_operations]
+            impl JsTensor {
+                pub fn $op(&self, other: Tensor) -> JsTensorResult {}
+                pub fn [<$op _>](&self, other: Tensor) -> JsTensorResult {}
+            }
+        }
+    };
+}
+
+macro_rules! impl_ternary_op {
+    ($op:ident) => {
+        paste! {
+            #[wasm_bindgen(js_class = Tensor)]
+            #[js_tensor_operations]
+            impl JsTensor {
+                pub fn $op(&self, tensor1: Tensor, tensor2: Tensor, value: f32) -> JsTensorResult {}
+                pub fn [<$op _>](&self, tensor1: Tensor, tensor2: Tensor, value: f32) -> JsTensorResult {}
+            }
+        }
+    };
+}
+
+macro_rules! impl_cmp_op {
+    ($op:ident) => {
+        paste! {
+            #[wasm_bindgen(js_class = Tensor)]
+            #[js_tensor_operations]
+            impl JsTensor {
+                pub fn $op(&self, other: Tensor) -> JsTensorResult {}
+                pub fn [<$op _>](&self, other: Tensor) -> JsTensorResult {}
+            }
+        }
+    };
+}
+
+macro_rules! impl_unary_op {
+    ($op:ident) => {
+        paste! {
+            #[wasm_bindgen(js_class = Tensor)]
+            #[js_tensor_operations]
+            impl JsTensor {
+                pub fn $op(&self) -> JsTensorResult {}
+                pub fn [<$op _>](&self) -> JsTensorResult {}
+            }
+        }
+    };
+}
+
+impl_binary_op!(add, |tensor: Tensor, other| tensor.affine(1., other));
+impl_binary_op!(add_, |tensor: Tensor, other| tensor.affine_(1., other));
+impl_binary_op!(sub, |tensor: Tensor, other: f32| tensor.affine(1., -other));
+impl_binary_op!(sub_, |tensor: Tensor, other: f32| tensor
+    .affine_(1., -other));
+impl_binary_op!(mul, |tensor: Tensor, other| tensor.affine(other, 0.));
+impl_binary_op!(mul_, |tensor: Tensor, other| tensor.affine_(other, 0.));
+impl_binary_op!(div, |tensor: Tensor, other| tensor.affine(1. / other, 0.));
+impl_binary_op!(div_, |tensor: Tensor, other| tensor.affine_(1. / other, 0.));
+
+impl_binary_op_tensor!(minimum);
+impl_binary_op_tensor!(maximum);
+
+impl_ternary_op!(addcdiv);
+impl_ternary_op!(addcmul);
+
+impl_cmp_op!(eq);
+impl_cmp_op!(ne);
+impl_cmp_op!(gt);
+impl_cmp_op!(ge);
+impl_cmp_op!(lt);
+impl_cmp_op!(le);
+
+impl_unary_op!(gelu);
+impl_unary_op!(tanh);
+impl_unary_op!(exp);
+impl_unary_op!(log);
+impl_unary_op!(sin);
+impl_unary_op!(cos);
+impl_unary_op!(abs);
+impl_unary_op!(sqrt);
+impl_unary_op!(relu);
+impl_unary_op!(relu2);
+impl_unary_op!(floor);
+impl_unary_op!(ceil);
+impl_unary_op!(neg);
+impl_unary_op!(sigmoid);
+impl_unary_op!(swiglu);
+impl_unary_op!(silu);
+impl_unary_op!(square);
+impl_unary_op!(recip);
+
+#[wasm_bindgen(js_class = Tensor)]
+#[js_tensor_operations]
+impl JsTensor {
+    #[dtype_generic]
+    pub fn full(
+        shape: Shape,
+        value: f32,
+        dtype: DType,
+        device: &Device,
+        requires_grad: bool,
+    ) -> JsTensorResult {
+    }
+
+    pub fn cast(&self, dst_dtype: DType) -> JsTensorResult {}
+
+    pub fn float(&self) -> JsTensorResult {}
+
+    pub fn half(&self) -> JsTensorResult {}
+
+    pub fn group_norm(
+        &self,
+        num_groups: usize,
+        weight: Tensor,
+        bias: Option<Tensor>,
+        eps: f32,
+    ) -> JsTensorResult {
+    }
+
+    pub fn layer_norm(&self, weight: Tensor, bias: Option<Tensor>, eps: f32) -> JsTensorResult {}
+
+    pub fn rms_norm(&self, weight: Tensor, eps: f32) -> JsTensorResult {}
+
+    pub fn conv1d(
+        &self,
+        weight: Tensor,
+        bias: Option<Tensor>,
+        stride: usize,
+        padding: usize,
+    ) -> JsTensorResult {
+    }
+
+    pub fn softmax(&self, dim: Dim) -> JsTensorResult {}
+
+    pub fn rope(&self, dim: Dim, base: f32, offset: usize) -> JsTensorResult {}
+
+    pub fn alibi(&self, max_bias: f32) -> JsTensorResult {}
+
+    pub fn matmul(&self, rhs: Tensor, trans_lhs: bool, trans_rhs: bool) -> JsTensorResult {}
+
+    pub fn gemm(
+        &self,
+        rhs: Tensor,
+        bias: Option<Tensor>,
+        trans_lhs: bool,
+        trans_rhs: bool,
+        trans_out: bool,
+    ) -> JsTensorResult {
+    }
+
+    pub fn affine(&self, mul: f32, add: f32) -> JsTensorResult {}
+
+    pub fn pow(self, e: f32) -> JsTensorResult {}
+
+    pub fn pow_(self, e: f32) -> JsTensorResult {}
+
+    pub fn sum(self, dim: Option<Dims>, keepdim: bool) -> JsTensorResult {
+        let tensor = if let Some(sum_dims) = dim {
+            if keepdim {
+                self.inner.sum_keepdim(sum_dims)
+            } else {
+                self.inner.sum(sum_dims)
+            }
+        } else {
+            self.inner.sum_all()
+        }
+        .map_err(|e| e.to_string())?;
+        Ok(JsTensor { inner: tensor })
+    }
+
+    pub fn mean(self, dim: Option<Dims>, keepdim: bool) -> JsTensorResult {
+        let tensor = if let Some(mean_dims) = dim {
+            if keepdim {
+                self.inner.mean_keepdim(mean_dims)
+            } else {
+                self.inner.mean(mean_dims)
+            }
+        } else {
+            self.inner.mean_all()
+        }
+        .map_err(|e| e.to_string())?;
+        Ok(JsTensor { inner: tensor })
+    }
+
+    pub fn var(self, dim: Option<Dims>, keepdim: bool) -> JsTensorResult {
+        let tensor = if let Some(var_dims) = dim {
+            if keepdim {
+                self.inner.var_keepdim(var_dims)
+            } else {
+                self.inner.var(var_dims)
+            }
+        } else {
+            self.inner.var_all()
+        }
+        .map_err(|e| e.to_string())?;
+        Ok(JsTensor { inner: tensor })
+    }
+
+    pub fn max(self, dim: Dim, keepdim: bool) -> JsTensorResult {
+        let tensor = if keepdim {
+            self.inner.max_keepdim(dim)
+        } else {
+            self.inner.max(dim)
+        }
+        .map_err(|e| e.to_string())?;
+        Ok(JsTensor { inner: tensor })
+    }
+
+    pub fn min(self, dim: Dim, keepdim: bool) -> JsTensorResult {
+        let tensor = if keepdim {
+            self.inner.min_keepdim(dim)
+        } else {
+            self.inner.min(dim)
+        }
+        .map_err(|e| e.to_string())?;
+        Ok(JsTensor { inner: tensor })
+    }
+
+    pub fn argmax(self, dim: Dim, keepdim: bool) -> JsTensorResult {
+        let tensor = if keepdim {
+            self.inner.argmax_keepdim(dim)
+        } else {
+            self.inner.argmax(dim)
+        }
+        .map_err(|e| e.to_string())?;
+        Ok(JsTensor { inner: tensor })
+    }
+
+    pub fn argmin(self, dim: Dim, keepdim: bool) -> JsTensorResult {
+        let tensor = if keepdim {
+            self.inner.argmin_keepdim(dim)
+        } else {
+            self.inner.argmin(dim)
+        }
+        .map_err(|e| e.to_string())?;
+        Ok(JsTensor { inner: tensor })
+    }
+
+    pub fn norm(self) -> JsTensorResult {}
+
+    pub fn flatten(self, start_dim: Option<Dim>, end_dim: Option<Dim>) -> JsTensorResult {
+        let start_dim = start_dim.unwrap_or(FromJsDim(0));
+        let end_dim = end_dim.unwrap_or(FromJsDim(-1));
+        let tensor = self
+            .inner
+            .flatten(start_dim, end_dim)
+            .map_err(|e| e.to_string())?;
+        Ok(JsTensor { inner: tensor })
+    }
+
+    pub fn slice(self, ranges: JsValue) -> JsTensorResult {
+        let ranges = ranges
+            .dyn_into::<js_sys::Array>()
+            .expect("Ranges must be an array")
+            .iter()
+            .map(|r| {
+                let range: js_sys::Array = r.clone().into();
+                let start = range.get(0).as_f64().map(|v| v as usize);
+                let end = range.get(1).as_f64().map(|v| v as usize);
+                if let Some(end) = end {
+                    start.expect("Invalid range")..end
+                } else {
+                    0usize..start.expect("Invalid range")
+                }
+            })
+            .collect::<Vec<_>>();
+        let result = self.inner.slice(&ranges).map_err(|e| e.to_string())?;
+        Ok(JsTensor { inner: result })
+    }
+
+    pub fn view(self, shape: ShapeWithOneHole) -> JsTensorResult {}
+
+    pub fn unsqueeze(self, dim: Dim) -> JsTensorResult {}
+
+    pub fn squeeze(self, dims: Option<Dims>) -> JsTensorResult {
+        let inner = self.inner.clone();
+        let result = match dims {
+            Some(dims) => inner.squeeze(dims),
+            None => inner.squeeze_all(),
+        }
+        .map_err(|e| e.to_string())?;
+        Ok(Self { inner: result })
+    }
+
+    pub fn cat(tensors: RVec<Tensor>, dim: Dim) -> JsTensorResult {}
+
+    pub fn stack(tensors: RVec<Tensor>, dim: Dim) -> JsTensorResult {}
+
+    pub fn permute(self, dims: Dims) -> JsTensorResult {}
+
+    pub fn cache(self, source: Tensor, dim: Dim, offset: usize) -> JsTensorResult {}
+
+    /// Returns a new tensor duplicating data from the original tensor. New dimensions are inserted
+    /// on the left.
+    pub fn broadcast_left(self, left_shape: Shape) -> JsTensorResult {}
+
+    pub fn broadcast_to(self, shape: Shape) -> JsTensorResult {}
+
+    pub fn index_select(self, indices: Tensor, dim: Dim) -> JsTensorResult {}
+
+    pub fn index_write(self, src: Tensor, write_start: Dims) -> JsTensorResult {}
+
+    pub fn where_cond(self, on_true: Tensor, on_false: Tensor) -> JsTensorResult {}
+
+    pub fn scatter_add(self, indices: Tensor, source: Tensor, dim: Dim) -> JsTensorResult {}
+
+    pub fn index_add_(self, indices: Tensor, source: Tensor, dim: Dim) -> JsTensorResult {}
+
+    pub fn gather(self, indices: Tensor, dim: Dim) -> JsTensorResult {}
+
+    pub fn triu(self, k: Option<i32>) -> JsTensorResult {}
+
+    pub fn triu_(self, k: Option<i32>) -> JsTensorResult {}
+
+    pub fn tril(self, k: Option<i32>) -> JsTensorResult {}
+
+    pub fn tril_(self, k: Option<i32>) -> JsTensorResult {}
+
+    #[dtype_generic(f32, f16)]
+    pub fn arange(
+        start: f32,
+        end: f32,
+        dtype: DType,
+        device: &Device,
+        requires_grad: bool,
+    ) -> JsTensorResult {
+    }
+
+    /// Creates a new 1D tensor with values from the interval `[start, end)` taken with a common
+    /// difference `step` from `start`.
+    #[dtype_generic]
+    pub fn arange_step(
+        start: f32,
+        end: f32,
+        step: f32,
+        dtype: DType,
+        device: &Device,
+        requires_grad: bool,
+    ) -> JsTensorResult {
+    }
+
+    #[dtype_generic(f32, i32, u32)]
+    pub fn randint(
+        low: f32,
+        high: f32,
+        shape: Shape,
+        dtype: DType,
+        device: Device,
+        requires_grad: bool,
+    ) -> JsTensorResult {
+    }
+
+    #[dtype_generic(f32, f16)]
+    pub fn randn(
+        mean: f32,
+        std: f32,
+        shape: Shape,
+        dtype: DType,
+        device: Device,
+        requires_grad: bool,
+    ) -> JsTensorResult {
+    }
+
+    #[dtype_generic(f32, f16)]
+    pub fn rand(
+        lo: f32,
+        up: f32,
+        shape: Shape,
+        dtype: DType,
+        device: Device,
+        requires_grad: bool,
+    ) -> JsTensorResult {
+    }
+
+    // We use the dtype of the tensor
+    pub fn bernoulli(self) -> JsTensorResult {}
+
+    pub fn bernoulli_(self) -> JsTensorResult {}
+
+    #[dtype_generic]
+    pub fn zeros(
+        shape: Shape,
+        dtype: DType,
+        device: &Device,
+        requires_grad: bool,
+    ) -> JsTensorResult {
+    }
+
+    #[dtype_generic]
+    pub fn zeros_like(
+        self,
+        dtype: DType,
+        device: Option<&Device>,
+        requires_grad: bool,
+    ) -> JsTensorResult {
+    }
+
+    #[dtype_generic]
+    pub fn ones(
+        shape: Shape,
+        dtype: DType,
+        device: &Device,
+        requires_grad: bool,
+    ) -> JsTensorResult {
+    }
+
+    #[dtype_generic]
+    pub fn ones_like(
+        self,
+        dtype: DType,
+        device: Option<&Device>,
+        requires_grad: bool,
+    ) -> JsTensorResult {
+    }
+
+    pub fn is_contiguous(&self) -> bool {
+        self.inner.is_contiguous()
+    }
+
+    pub fn contiguous(self) -> JsTensorResult {}
+
+    pub fn from_data(
+        data: JsValue,
+        shape: Shape,
+        device: &Device,
+        requires_grad: bool,
+    ) -> JsTensorResult {
+        let tensor = if data.is_array() {
+            let array = data
+                .dyn_into::<js_sys::Array>()
+                .map_err(|_| JsValue::from_str("Failed to convert data to array"))?;
+
+            let data = array
+                .iter()
+                .map(|v| {
+                    v.as_f64()
+                        .map(|f| f as f32)
+                        .ok_or_else(|| JsValue::from_str("Array contains non-numeric values"))
+                })
+                .collect::<Result<Vec<f32>, JsValue>>()?;
+
+            Tensor::from_data(data, shape, device.clone(), requires_grad)
+        } else if js_sys::Float32Array::instanceof(&data) {
+            let array = js_sys::Float32Array::from(data);
+            let data = array.to_vec().into_iter().collect::<Vec<_>>();
+            Tensor::from_data(data, shape, device.clone(), requires_grad)
+        } else if js_sys::Float64Array::instanceof(&data) {
+            let array = js_sys::Float64Array::from(data);
+            let data = array
+                .to_vec()
+                .into_iter()
+                .map(|v| v as f32)
+                .collect::<Vec<_>>();
+            Tensor::from_data(data, shape, device.clone(), requires_grad)
+        } else if js_sys::Int32Array::instanceof(&data) {
+            let array = js_sys::Int32Array::from(data);
+            let data = array.to_vec().into_iter().collect::<Vec<_>>();
+            Tensor::from_data(data, shape, device.clone(), requires_grad)
+        } else if js_sys::Uint32Array::instanceof(&data) {
+            let array = js_sys::Uint32Array::from(data);
+            let data = array.to_vec().into_iter().collect::<Vec<_>>();
+            Tensor::from_data(data, shape, device.clone(), requires_grad)
+        } else {
+            return Err(JsValue::from_str("Unsupported data type"));
+        };
+        Ok(JsTensor { inner: tensor })
+    }
+
+    pub fn from_bytes(
+        data: &[u8],
+        dtype: DType,
+        shape: Shape,
+        device: Device,
+        requires_grad: bool,
+    ) -> JsTensorResult {
+    }
+
+    pub fn detach(&self) -> JsTensor {
+        JsTensor {
+            inner: self.inner.detach(),
+        }
+    }
+
+    pub fn detach_(&self) -> JsTensor {
+        JsTensor {
+            inner: self.inner.detach_(),
+        }
+    }
+
+    #[wasm_bindgen(js_name = requiresGrad_)]
+    pub fn requires_grad_(&self, requires_grad: bool) -> JsTensorResult {}
+
+    // Skipping copy; the api is not great right now
+
+    // Skipping into_bytes; probably won't work great with reference counting
+
+    // Skipping from_quantized; we don't really have well-rounded quantized support right now
+
+    // Skipping from_disk; not clear what it would represent in the JS API
+}
+
+#[wasm_bindgen(js_class = Tensor)]
+impl JsTensor {
+    #[wasm_bindgen(js_name = toVec, unchecked_return_type = "Float32Array | Int32Array | Uint32Array")]
+    pub async fn to_vec(&self, dtype: Option<JsDType>) -> Result<JsValue, JsValue> {
+        let dtype = dtype.map(|d| d.dtype).unwrap_or(self.inner.dtype());
+        match dtype {
+            DType::F32 => {
+                let result = self
+                    .inner
+                    .to_vec::<f32>()
+                    .await
+                    .map_err(|e| JsValue::from(e.to_string()))?;
+                let array = js_sys::Float32Array::new_with_length(result.len() as u32);
+                array.copy_from(&result);
+                Ok(array.into())
+            }
+            DType::F16 => {
+                let result = self
+                    .inner
+                    .to_vec::<f16>()
+                    .await
+                    .map_err(|e| JsValue::from(e.to_string()))?;
+                let f32_vec: Vec<f32> = result.iter().map(|&x| f16::to_f32(x)).collect();
+                let array = js_sys::Float32Array::new_with_length(f32_vec.len() as u32);
+                array.copy_from(&f32_vec);
+                Ok(array.into())
+            }
+            DType::I32 => {
+                let result = self
+                    .inner
+                    .to_vec::<i32>()
+                    .await
+                    .map_err(|e| JsValue::from(e.to_string()))?;
+                let array = js_sys::Int32Array::new_with_length(result.len() as u32);
+                array.copy_from(&result);
+                Ok(array.into())
+            }
+            DType::U32 => {
+                let result = self
+                    .inner
+                    .to_vec::<u32>()
+                    .await
+                    .map_err(|e| JsValue::from(e.to_string()))?;
+                let array = js_sys::Uint32Array::new_with_length(result.len() as u32);
+                array.copy_from(&result);
+                Ok(array.into())
+            }
+            _ => {
+                panic!("Unsupported dtype");
+            }
+        }
+    }
+
+    #[wasm_bindgen(unchecked_return_type = "number")]
+    pub async fn item(&self, dtype: Option<JsDType>) -> Result<JsValue, JsValue> {
+        let dtype = dtype.map(|d| d.dtype).unwrap_or(self.inner.dtype());
+        match dtype {
+            DType::F32 => Ok(JsValue::from_f64(self.inner.item::<f32>().await as f64)),
+            DType::F16 => Ok(JsValue::from_f64(
+                f16::to_f32(self.inner.item::<f16>().await) as f64,
+            )),
+            DType::I32 => Ok(JsValue::from_f64(self.inner.item::<i32>().await as f64)),
+            DType::U32 => Ok(JsValue::from_f64(self.inner.item::<u32>().await as f64)),
+            _ => panic!("Unsupported dtype"),
+        }
+    }
+
+    pub async fn to(&self, device: String) -> Result<JsTensor, JsValue> {
+        let device = match device.as_str() {
+            "cpu" => Device::CPU,
+            "gpu" | "webgpu" => {
+                GPU_DEVICE.with(|device| device.borrow().clone().unwrap().inner.clone())
+            }
+            _ => return Err(JsValue::from_str("Unsupported device")),
+        };
+        let inner = self
+            .inner
+            .to(&device)
+            .await
+            .map_err(|e| JsValue::from(e.to_string()))?;
+        Ok(JsTensor { inner })
+    }
+
+    #[wasm_bindgen(js_name = hasNaN)]
+    pub fn has_nan(&self, dtype: Option<JsDType>) -> bool {
+        let dtype = dtype.map(|d| d.dtype).unwrap_or(self.inner.dtype());
+        match dtype {
+            DType::F32 => self.inner.has_nan::<f32>(),
+            DType::F16 => self.inner.has_nan::<f16>(),
+            _ => panic!("Unsupported dtype"),
+        }
+    }
+
+    pub fn grad(&self) -> Result<Option<JsTensor>, JsValue> {
+        Ok(self.inner.grad().map(|grad| JsTensor { inner: grad }))
+    }
+
+    #[cfg(not(feature = "debug"))]
+    #[wasm_bindgen(js_name = debugTensor)]
+    pub fn debug_tensor(&self) -> Result<JsTensor, JsValue> {
+        let tensor = self
+            .inner
+            .get_or_create_debug_tensor()
+            .map_err(|e| JsValue::from(e.to_string()))?;
+        Ok(JsTensor { inner: tensor })
+    }
+
+    pub fn backward(&self) -> Result<(), JsValue> {
+        self.inner
+            .backward()
+            .map_err(|e| JsValue::from(e.to_string()))
+    }
+}
+
+#[wasm_bindgen(js_class = Tensor)]
+impl JsTensor {
+    #[wasm_bindgen]
+    pub fn _clone(&self) -> JsTensor {
+        JsTensor {
+            inner: self.inner.clone(),
+        }
+    }
+}
+
+fn convert_ir_fields_to_js(
+    fields: &HashMap<String, IrValue, impl std::hash::BuildHasher>,
+    op: &LazyOp,
+) -> JsValue {
+    let obj = js_sys::Object::new();
+
+    for (key, value) in fields {
+        js_sys::Reflect::set(&obj, &key.into(), &convert_ir_value_to_js(value, op)).unwrap();
+    }
+
+    obj.into()
+}
+
+// Helper function to convert individual IrValue to JsValue
+fn convert_ir_value_to_js(value: &IrValue, op: &LazyOp) -> JsValue {
+    match value {
+        IrValue::Tensor(tensor_value) => {
+            // Get the tensor from the operation's sources
+            if let Some(tensor) = op.srcs().iter().find(|t| t.id() == tensor_value.id) {
+                let js_tensor = JsTensor {
+                    inner: Tensor::wrap((*tensor).clone()),
+                };
+                JsValue::from(js_tensor)
+            } else {
+                JsValue::NULL
+            }
+        }
+        // Handle scalar values
+        IrValue::Scalar(scalar) => match scalar {
+            IrScalarValue::F32(val) => JsValue::from_f64(*val as f64),
+            IrScalarValue::I32(val) => JsValue::from_f64(*val as f64),
+            IrScalarValue::U32(val) => JsValue::from_f64(*val as f64),
+            IrScalarValue::Bool(val) => JsValue::from_bool(*val),
+            IrScalarValue::String(val) => JsValue::from_str(val),
+            IrScalarValue::Vec4U32(val) => {
+                let array = js_sys::Array::new();
+                array.push(&JsValue::from_f64(val.x as f64));
+                array.push(&JsValue::from_f64(val.y as f64));
+                array.push(&JsValue::from_f64(val.z as f64));
+                array.push(&JsValue::from_f64(val.w as f64));
+                array.into()
+            }
+        },
+        // Handle nested IR
+        IrValue::Ir(nested_ir) => {
+            let obj = js_sys::Object::new();
+            js_sys::Reflect::set(&obj, &"name".into(), &JsValue::from_str(nested_ir.name()))
+                .unwrap();
+
+            if let Some(nested_fields) = nested_ir.fields() {
+                js_sys::Reflect::set(
+                    &obj,
+                    &"fields".into(),
+                    &convert_ir_fields_to_js(nested_fields, op),
+                )
+                .unwrap();
+            }
+
+            obj.into()
+        }
+        // Handle Fields (should not happen in finalized op)
+        IrValue::Fields(_) => JsValue::NULL,
+        // Handle Vectors of IrValues
+        IrValue::Vec(vec_values) => {
+            let array = js_sys::Array::new();
+            for value in vec_values.iter() {
+                array.push(&convert_ir_value_to_js(value, op));
+            }
+            array.into()
+        }
+        // Handle None
+        IrValue::None => JsValue::NULL,
+    }
+}
+
+#[wasm_bindgen(module = "/cast.js")]
+extern "C" {
+    #[wasm_bindgen(catch, js_name = cast)]
+    fn try_into_tensor(from: &JsValue) -> Result<JsTensor, JsValue>;
+}
+
+impl TryFrom<JsValue> for JsTensor {
+    type Error = JsValue;
+    fn try_from(value: JsValue) -> Result<Self, Self::Error> {
+        try_into_tensor(&value)
+    }
+}

--- a/package.json
+++ b/package.json
@@ -11,5 +11,13 @@
     "onlyBuiltDependencies": [
       "esbuild"
     ]
+  },
+  "scripts": {
+    "build": "pnpm -r build",
+    "test": "pnpm -r test",
+    "lint": "pnpm -r lint",
+    "changeset": "changeset",
+    "version": "changeset version",
+    "publish": "pnpm build && changeset publish"
   }
 }

--- a/packages/web/.editorconfig
+++ b/packages/web/.editorconfig
@@ -1,0 +1,13 @@
+#root = true
+
+[*]
+indent_style = space
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+max_line_length = 100
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false

--- a/packages/web/.gitignore
+++ b/packages/web/.gitignore
@@ -1,0 +1,11 @@
+node_modules
+coverage
+.DS_Store
+*.log
+.vscode
+.idea
+
+dist
+
+pnpm-lock.yaml
+yarn.lock

--- a/packages/web/.prettierignore
+++ b/packages/web/.prettierignore
@@ -1,0 +1,5 @@
+dist
+coverage
+.rpt2_cache
+node_modules
+docs

--- a/packages/web/README.md
+++ b/packages/web/README.md
@@ -1,0 +1,3 @@
+# piston JS lib
+
+A relatively thin wrapper around the WASM core.

--- a/packages/web/eslint.config.js
+++ b/packages/web/eslint.config.js
@@ -1,0 +1,68 @@
+import eslint from "@eslint/js";
+import prettierConfig from "eslint-config-prettier";
+import perfectionist from "eslint-plugin-perfectionist";
+import prettier from "eslint-plugin-prettier";
+import globals from "globals";
+import tseslint from "typescript-eslint";
+
+export default tseslint.config(
+  eslint.configs.recommended,
+  tseslint.configs.recommended,
+  prettierConfig,
+  {
+    ignores: ["node_modules", "dist", "typings"],
+    languageOptions: {
+      ecmaVersion: "latest",
+      globals: {
+        ...globals.browser,
+        ...globals.node,
+        ...globals.es2021,
+      },
+      parserOptions: {
+        ecmaVersion: "latest",
+        sourceType: "module",
+      },
+      sourceType: "module",
+    },
+    plugins: {
+      prettier,
+      perfectionist,
+    },
+    rules: {
+      "@typescript-eslint/ban-types": "off",
+      "@typescript-eslint/no-explicit-any": "warn",
+      "@typescript-eslint/no-unused-vars": [
+        "warn",
+        {
+          argsIgnorePattern: "^_",
+          caughtErrorsIgnorePattern: "^_",
+          varsIgnorePattern: "^_",
+        },
+      ],
+      "@typescript-eslint/no-var-requires": "off",
+      "no-unused-vars": "off",
+      "perfectionist/sort-imports": [
+        "error",
+        {
+          type: "natural",
+          order: "asc",
+          groups: [
+            "type",
+            ["builtin", "external"],
+            "internal-type",
+            "internal",
+            ["parent-type", "sibling-type", "index-type"],
+            ["parent", "sibling", "index"],
+            "side-effect",
+            "style",
+            "object",
+            "unknown",
+          ],
+        },
+      ],
+      "perfectionist/sort-exports": ["error", { type: "natural" }],
+      "perfectionist/sort-named-exports": ["error", { type: "natural" }],
+      "perfectionist/sort-named-imports": ["error", { type: "natural" }],
+    },
+  },
+);

--- a/packages/web/jsr.json
+++ b/packages/web/jsr.json
@@ -1,0 +1,12 @@
+{
+  "name": "@vinhowe/piston",
+  "version": "0.0.0",
+  "exports": "./src/index.ts",
+  "publish": {
+    "include": [
+      "LICENSE",
+      "README.md",
+      "src/**/*.ts"
+    ]
+  }
+}

--- a/packages/web/jsr.release.js
+++ b/packages/web/jsr.release.js
@@ -1,0 +1,4 @@
+require('node:fs').writeFileSync('jsr.json', JSON.stringify({
+  ...require('./jsr.json'),
+  "version": require('./package.json').version,
+}, null, 2) + '\n');

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,0 +1,146 @@
+{
+  "name": "@piston-ml/piston-web",
+  "version": "0.0.0",
+  "homepage": "https://piston.vin.how",
+  "type": "module",
+  "main": "./dist/piston.module.mjs",
+  "module": "./dist/piston.module.mjs",
+  "types": "./dist/types/index.d.ts",
+  "source": "src/index.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/types/index.d.ts",
+      "browser": "./dist/browser.module.mjs",
+      "import": "./dist/piston.module.mjs",
+      "default": "./dist/piston.module.mjs"
+    }
+  },
+  "sideEffects": false,
+  "files": [
+    "dist"
+  ],
+  "author": "Vin Howe <vin@vin.how>",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/vinhowe/piston.git"
+  },
+  "bugs": {
+    "url": "https://github.com/vinhowe/piston/issues"
+  },
+  "license": "MIT",
+  "engines": {
+    "node": ">=18.0.0"
+  },
+  "scripts": {
+    "build:node": "rollup --config rollup.config.ts -i src/index.ts --configPlugin typescript",
+    "build:browser": "rollup --config rollup.config.ts -i src/browser.ts --configPlugin typescript",
+    "build": "rollup --config rollup.config.ts --configPlugin typescript",
+    "format": "prettier --write '{src,test}/**/**.ts'",
+    "lint": "eslint src/**/*.ts --ext .js,.ts",
+    "prebuild": "rimraf dist",
+    "release": "npm run build && np && npx jsr publish",
+    "postversion": "node ./jsr.release.js",
+    "size": "size-limit",
+    "start": "rollup --config rollup.config.ts -w --configPlugin typescript",
+    "test": "jest --coverage && npm run size",
+    "test:prod": "npm run lint && npm run test -- --no-cache",
+    "test:watch": "jest --coverage --watch"
+  },
+  "size-limit": [
+    {
+      "path": "dist/browser.module.mjs",
+      "limit": "3.5 KB"
+    }
+  ],
+  "lint-staged": {
+    "{src,test}/**/**.ts": [
+      "eslint"
+    ]
+  },
+  "config": {
+    "commitizen": {
+      "path": "node_modules/cz-conventional-changelog"
+    }
+  },
+  "jest": {
+    "transform": {
+      ".(ts)": "ts-jest"
+    },
+    "moduleNameMapper": {
+      "^(\\.{1,2}/.*)\\.js$": "$1"
+    },
+    "testEnvironment": "node",
+    "testRegex": "\\/test\\/.*(\\.spec\\.ts)$",
+    "moduleFileExtensions": [
+      "ts",
+      "js"
+    ],
+    "coveragePathIgnorePatterns": [
+      "/node_modules/",
+      "/test/"
+    ],
+    "coverageThreshold": {
+      "global": {
+        "branches": 85,
+        "functions": 95,
+        "lines": 95,
+        "statements": 95
+      }
+    },
+    "collectCoverageFrom": [
+      "src/!(browser).ts"
+    ]
+  },
+  "commitlint": {
+    "extends": [
+      "@commitlint/config-conventional"
+    ]
+  },
+  "dependencies": {
+    "@piston/piston-web": "link:../../target/pkg/piston-web"
+  },
+  "devDependencies": {
+    "@commitlint/cli": "^19.8.0",
+    "@commitlint/config-conventional": "^19.8.0",
+    "@rollup/plugin-alias": "^5.1.1",
+    "@rollup/plugin-commonjs": "^28.0.3",
+    "@rollup/plugin-node-resolve": "^16.0.1",
+    "@rollup/plugin-terser": "^0.4.4",
+    "@rollup/plugin-typescript": "^12.1.2",
+    "@rollup/plugin-wasm": "^6.2.2",
+    "@size-limit/preset-small-lib": "^11.2.0",
+    "@types/jest": "^29.4.0",
+    "@types/node": "^18.14.2",
+    "@typescript-eslint/eslint-plugin": "^8.26.1",
+    "@typescript-eslint/parser": "^8.26.1",
+    "commitizen": "^4.3.0",
+    "coveralls": "^3.1.1",
+    "cross-env": "^7.0.3",
+    "cz-conventional-changelog": "^3.3.0",
+    "eslint": "^9.22.0",
+    "eslint-config-prettier": "^10.1.1",
+    "eslint-plugin-perfectionist": "^4.10.1",
+    "eslint-plugin-prettier": "^5.2.3",
+    "globals": "^15.14.0",
+    "husky": "^9.1.7",
+    "jest": "^29.4.3",
+    "lint-staged": "^15.5.0",
+    "microbundle": "^0.15.1",
+    "np": "^10.2.0",
+    "prettier": "^3.5.3",
+    "rimraf": "^6.0.1",
+    "rollup": "^4.35.0",
+    "shelljs": "^0.9.1",
+    "size-limit": "^11.2.0",
+    "ts-jest": "^29.0.5",
+    "ts-node": "^10.9.1",
+    "tsc-alias": "^1.8.11",
+    "tslib": "^2.5.0",
+    "typescript": "^5.1.3"
+  },
+  "husky": {
+    "hooks": {
+      "pre-commit": "lint-staged"
+    }
+  }
+}

--- a/packages/web/rollup.config.ts
+++ b/packages/web/rollup.config.ts
@@ -1,0 +1,106 @@
+import commonjs from "@rollup/plugin-commonjs";
+import resolve from "@rollup/plugin-node-resolve";
+import terser from "@rollup/plugin-terser";
+import typescript from "@rollup/plugin-typescript";
+import { replaceTscAliasPaths } from "tsc-alias";
+
+/**
+ * Creates a Rollup plugin that replaces TypeScript alias paths in compiled output
+ * @param {import("tsc-alias").ReplaceTscAliasPathsOptions} options - Configuration options for tsc-alias
+ * @returns {Object} Rollup plugin
+ */
+function tscAlias(options) {
+  return {
+    name: "tscAlias",
+    async writeBundle() {
+      return replaceTscAliasPaths(options);
+    },
+  };
+}
+
+const createConfig = ({
+  format,
+  input,
+  outputFile,
+  browser = false,
+  minify = false,
+}) => {
+  const plugins = [
+    // Resolve node modules
+    resolve({
+      browser,
+      preferBuiltins: !browser,
+    }),
+    // Convert CommonJS modules to ES modules
+    commonjs(),
+    // Process TypeScript files
+    typescript({
+      tsconfig: "./tsconfig.json",
+      sourceMap: true,
+      declaration: true,
+      declarationDir: "dist/types",
+      rootDir: "./src",
+    }),
+    tscAlias({
+      outDir: "dist/types",
+      declarationDir: "dist/types",
+    }),
+  ];
+
+  // Add minification for production builds
+  if (minify) {
+    plugins.push(terser({
+      mangle: {
+        // We do this so that we can keep track of module scopes
+        keep_classnames: true,
+      },
+    }));
+  }
+
+  return {
+    input,
+    output: {
+      file: outputFile,
+      format,
+      sourcemap: true,
+      // Preserve imported WASM module names for better debugging
+      interop: "auto",
+      // Export individual named exports in ES format
+      exports: "named",
+    },
+    // Make sure we externalize the @piston/piston-web dependency
+    // so it's loaded at runtime via dynamic import
+    external: ["@piston/piston-web"],
+    plugins,
+    // Ensure WASM imports are properly handled
+    onwarn(warning, warn) {
+      // Ignore certain warnings
+      if (warning.code === "CIRCULAR_DEPENDENCY") return;
+      // Ignore dynamic import warnings
+      if (
+        warning.code === "UNRESOLVED_IMPORT" &&
+        warning.source?.includes("@piston/piston-web")
+      )
+        return;
+      warn(warning);
+    },
+  };
+};
+
+export default [
+  // ESM build for Node.js
+  createConfig({
+    format: "es",
+    input: "src/index.ts",
+    outputFile: "dist/piston.module.mjs",
+  }),
+
+  // Browser ESM build
+  createConfig({
+    format: "es",
+    input: "src/browser.ts",
+    outputFile: "dist/browser.module.mjs",
+    browser: true,
+    minify: true,
+  }),
+];

--- a/packages/web/src/browser.ts
+++ b/packages/web/src/browser.ts
@@ -1,0 +1,1 @@
+export * from "@/core";

--- a/packages/web/src/core.ts
+++ b/packages/web/src/core.ts
@@ -1,0 +1,64 @@
+import { initGlobals } from "@/globals";
+import { wasmInit } from "@/wasm";
+
+// Track initialization state
+let isInitialized = false;
+
+async function init(): Promise<void> {
+  if (isInitialized) {
+    console.warn("WASM module already initialized");
+    return;
+  }
+
+  try {
+    await wasmInit();
+    isInitialized = true;
+  } catch (e: unknown) {
+    const error = e as Error;
+    console.error("Failed to initialize piston WASM module:", error);
+    console.error("Error details:", {
+      message: error.message,
+      cause: error.cause
+        ? (error.cause as unknown as { message: string }).message
+        : "unknown",
+      stack: error.stack,
+    });
+    throw error;
+  }
+
+  await initGlobals();
+}
+
+export {
+  arange,
+  bernoulli,
+  cat,
+  cpu,
+  float16,
+  float32,
+  full,
+  gpu,
+  int32,
+  ones,
+  onesLike,
+  rand,
+  randint,
+  randn,
+  randnMeanStd,
+  seed,
+  stack,
+  tensor,
+  uint32,
+  zeros,
+  zerosLike,
+} from "@/globals";
+export * as nn from "@/nn";
+export * from "@/nn";
+export { debugBufferHook } from "@/nn/moduleUtils";
+export * as optim from "@/optim";
+export * from "@/optim";
+export { Parameter } from "@/parameter";
+export { save } from "@/serialization";
+export { Tensor } from "@/tensor";
+export { Device, DType } from "@/wasm";
+export { init };

--- a/packages/web/src/globals.ts
+++ b/packages/web/src/globals.ts
@@ -1,0 +1,337 @@
+import { Parameter } from "@/parameter";
+import { Tensor } from "@/tensor";
+import {
+  FullInitConfig,
+  NestedNumberList,
+  OptionalShapeConfig,
+  RequiresGradConfig,
+  ShapeType,
+  TensorCreationFunction,
+  VarConfig,
+} from "@/types";
+import { inferShapeFromNestedArray } from "@/utils";
+import {
+  cpu_wasm,
+  Device,
+  DType,
+  float16_wasm,
+  float32_wasm,
+  gpu_wasm,
+  int32_wasm,
+  seed_wasm,
+  Tensor_wasm,
+  uint32_wasm,
+} from "@/wasm";
+
+// dtypes
+export let float32: DType;
+export let float16: DType;
+export let int32: DType;
+export let uint32: DType;
+
+// devices
+export let cpu: Device;
+export let gpu: Device;
+
+// general utils
+export let seed: (seed: number) => void;
+
+// tensor creation functions
+export let full: TensorCreationFunction<[shape: ShapeType, value: number]>;
+export let cat: (tensors: Tensor[], dim: number) => Tensor;
+export let stack: (tensors: Tensor[], dim: number) => Tensor;
+export let arange: TensorCreationFunction<
+  [start: number, end?: number, step?: number]
+>;
+export let randint: TensorCreationFunction<
+  [low: number, high: number, shape: ShapeType]
+>;
+export let randn: TensorCreationFunction<[shape: ShapeType]>;
+export let randnMeanStd: TensorCreationFunction<
+  [mean: number, std: number, shape: ShapeType]
+>;
+export let rand: TensorCreationFunction<
+  [lo: number, up: number, shape: ShapeType]
+>;
+// This just calls .bernoulli() on the tensor
+export let bernoulli: (t: Tensor) => Tensor;
+export let zeros: TensorCreationFunction<[shape: ShapeType]>;
+export let zerosLike: TensorCreationFunction<[t: Tensor]>;
+export let ones: TensorCreationFunction<[shape: ShapeType]>;
+export let onesLike: TensorCreationFunction<[t: Tensor]>;
+
+export let tensor: {
+  (
+    data: CreateTensorData,
+    config: RequiresGradConfig & OptionalShapeConfig,
+  ): Parameter;
+  (
+    data: CreateTensorData,
+    config?: FullInitConfig & OptionalShapeConfig,
+  ): Tensor;
+};
+
+type CreateTensorData =
+  | number[]
+  | NestedNumberList[]
+  | Uint8Array
+  | Float32Array
+  | Float64Array
+  | Int32Array
+  | Uint32Array;
+
+function parseDevice(device?: Device | string | undefined): Device {
+  if (typeof device === "string") {
+    if (device === "cpu") {
+      return cpu._clone();
+    } else if (device === "webgpu" || device === "gpu") {
+      return gpu._clone();
+    } else {
+      throw new Error(`Unknown device: ${device}`);
+    }
+  }
+  return (device ?? gpu)._clone();
+}
+
+function parseDType(dtype?: DType | string | undefined): DType {
+  if (typeof dtype === "string") {
+    if (dtype === "float32") {
+      return float32._clone();
+    } else if (dtype === "float16") {
+      return float16._clone();
+    } else if (dtype === "int32") {
+      return int32._clone();
+    } else if (dtype === "uint32") {
+      return uint32._clone();
+    }
+    throw new Error(`Unknown dtype: ${dtype}`);
+  }
+
+  return (dtype ?? float32)._clone();
+}
+
+function tensorCreationArgs(config?: FullInitConfig): [DType, Device, boolean] {
+  return [
+    parseDType(config?.dtype),
+    parseDevice(config?.device),
+    config?.requiresGrad ?? false,
+  ];
+}
+
+function unwrapFullConfigArgs<Args extends unknown[]>(
+  fn: (...args: [...Args, DType, Device, boolean]) => Tensor_wasm,
+): (...args: [...Args, FullInitConfig?]) => Tensor_wasm {
+  return (...args: [...Args, FullInitConfig?]) => {
+    let configArg = args[args.length - 1] as FullInitConfig | undefined;
+    let restArgs;
+    if (
+      (configArg &&
+        Object.prototype.hasOwnProperty.call(
+          configArg as Record<string, unknown>,
+          "device",
+        )) ||
+      Object.prototype.hasOwnProperty.call(
+        configArg as Record<string, unknown>,
+        "dtype",
+      ) ||
+      Object.prototype.hasOwnProperty.call(
+        configArg as Record<string, unknown>,
+        "requiresGrad",
+      )
+    ) {
+      // We have a config argument, so we need to remove it from the rest of the
+      // arguments
+      restArgs = args.slice(0, args.length - 1) as Args;
+    } else {
+      restArgs = args as unknown as Args;
+      configArg = undefined;
+    }
+
+    const tensor = fn(
+      ...restArgs,
+      configArg?.dtype?._clone() ?? float32._clone(),
+      parseDevice(configArg?.device),
+      configArg?.requiresGrad ?? false,
+    );
+    return tensor;
+  };
+}
+
+function wrapWithLibTensor<Args extends unknown[]>(
+  fn: (...args: Args) => Tensor_wasm,
+): (...args: Args) => Tensor {
+  return (...args: Args) => {
+    return Tensor._wrap(fn(...args));
+  };
+}
+
+function wrapWithParam<Args extends unknown[]>(
+  fn: (...args: [...Args, VarConfig?]) => Tensor,
+): TensorCreationFunction<Args> {
+  return (...args: [...Args, VarConfig?]): Parameter => {
+    const configArg = args[args.length - 1] as VarConfig | undefined;
+    const restArgs = args.slice(0, args.length - 1) as Args;
+
+    const tensor = fn(...restArgs, configArg);
+    if (configArg?.requiresGrad) {
+      // Create a Parameter from the tensor and wrap it with proxy
+      return new Parameter(tensor);
+    }
+    return tensor;
+  };
+}
+
+export async function initGlobals() {
+  float32 = float32_wasm();
+  float16 = float16_wasm();
+  int32 = int32_wasm();
+  uint32 = uint32_wasm();
+
+  cpu = await cpu_wasm();
+  gpu = await gpu_wasm();
+  seed = (seed: number | bigint) => {
+    seed_wasm(typeof seed === "bigint" ? seed : BigInt(seed));
+  };
+
+  full = wrapWithParam(
+    wrapWithLibTensor(unwrapFullConfigArgs(Tensor_wasm.full)),
+  );
+  cat = wrapWithLibTensor((tensors: Tensor[], dim: number) => {
+    return Tensor_wasm.cat(
+      tensors.map((t) => Tensor._unwrap(t)),
+      dim,
+    );
+  });
+  stack = wrapWithLibTensor((tensors: Tensor[], dim: number) => {
+    return Tensor_wasm.stack(
+      tensors.map((t) => Tensor._unwrap(t)),
+      dim,
+    );
+  });
+  arange = wrapWithParam(
+    wrapWithLibTensor(
+      (start: number, end?: number, step?: number, config?: FullInitConfig) => {
+        if (end === undefined) {
+          end = start;
+          start = 0;
+        }
+        if (step === undefined) {
+          step = 1;
+        }
+        return Tensor_wasm.arangeStep(
+          start,
+          end,
+          step,
+          ...tensorCreationArgs(config),
+        );
+      },
+    ),
+  );
+  randint = wrapWithParam(
+    wrapWithLibTensor(unwrapFullConfigArgs(Tensor_wasm.randint)),
+  );
+  // This puts us in line with the PyTorch API
+  randn = wrapWithParam(
+    wrapWithLibTensor((shape?: ShapeType, config?: FullInitConfig) => {
+      return Tensor_wasm.randn(
+        0,
+        1,
+        shape as Uint32Array,
+        ...tensorCreationArgs(config),
+      );
+    }),
+  );
+  randnMeanStd = wrapWithParam(
+    wrapWithLibTensor(unwrapFullConfigArgs(Tensor_wasm.randn)),
+  );
+  rand = wrapWithParam(
+    wrapWithLibTensor(unwrapFullConfigArgs(Tensor_wasm.rand)),
+  );
+  bernoulli = wrapWithLibTensor((t: Tensor) => Tensor._unwrap(t).bernoulli());
+  zeros = wrapWithParam(
+    wrapWithLibTensor(unwrapFullConfigArgs(Tensor_wasm.zeros)),
+  );
+  zerosLike = wrapWithParam(
+    wrapWithLibTensor((t: Tensor, config?: FullInitConfig) => {
+      return Tensor._unwrap(t).zerosLike(...tensorCreationArgs(config));
+    }),
+  );
+  ones = wrapWithParam(
+    wrapWithLibTensor(unwrapFullConfigArgs(Tensor_wasm.ones)),
+  );
+  onesLike = wrapWithParam(
+    wrapWithLibTensor((t: Tensor, config?: FullInitConfig) => {
+      return Tensor._unwrap(t).onesLike(...tensorCreationArgs(config));
+    }),
+  );
+  tensor = wrapWithParam(
+    wrapWithLibTensor(
+      (
+        data:
+          | NestedNumberList[]
+          | Uint8Array
+          | Float32Array
+          | Float64Array
+          | Int32Array
+          | Uint32Array,
+        config?: FullInitConfig & OptionalShapeConfig,
+      ) => {
+        // Infer shape here, if we're looking at a nested number list
+        let shape: ShapeType | undefined = config?.shape;
+
+        let dataShape;
+        if (Array.isArray(data)) {
+          // For nested arrays, recursively determine shape
+          dataShape = inferShapeFromNestedArray(data);
+        } else {
+          // For TypedArrays, use length as a 1D shape
+          dataShape = [data.length];
+        }
+
+        const dataNumel = dataShape.reduce((a, b) => a * b, 1);
+
+        if (!shape) {
+          shape = dataShape;
+        } else {
+          // Verify that data shape and shape are correct
+          const providedShapeArray = Array.isArray(shape)
+            ? shape
+            : Array.from(shape);
+          const shapeNumel = providedShapeArray.reduce((a, b) => a * b, 1);
+          if (shapeNumel !== dataNumel) {
+            throw Error(
+              `Data shape [${dataShape}] can't be reshaped to provided shape [${providedShapeArray}]`,
+            );
+          }
+        }
+
+        let castData;
+        if (Array.isArray(data)) {
+          data = data.flat();
+        }
+        if (config?.dtype) {
+          if (config.dtype === float32) {
+            castData = new Float32Array(data as number[]);
+          } else if (config.dtype === float16) {
+            castData = new Float16Array(data as number[]);
+          } else if (config.dtype === int32) {
+            castData = new Int32Array(data as number[]);
+          } else if (config.dtype === uint32) {
+            castData = new Uint32Array(data as number[]);
+          }
+        } else {
+          castData = Array.isArray(data)
+            ? new Float32Array(data as number[])
+            : data;
+        }
+
+        return Tensor_wasm.fromData(
+          castData,
+          shape,
+          parseDevice(config?.device),
+          config?.requiresGrad ?? false,
+        );
+      },
+    ),
+  );
+}

--- a/packages/web/src/index.ts
+++ b/packages/web/src/index.ts
@@ -1,0 +1,1 @@
+export * from "@/core";

--- a/packages/web/src/nn/activation.ts
+++ b/packages/web/src/nn/activation.ts
@@ -1,0 +1,20 @@
+import { Module } from "@/nn/module";
+import { Tensor } from "@/tensor";
+
+export class LogSoftmax extends Module {
+  constructor(private dim: number = 1) {
+    super();
+  }
+
+  forward(input: Tensor): Tensor {
+    // TODO: Make this a custom operation (shouldn't be hard; just need to add
+    // log as an option to the softmax operation, including the max subtract)
+    //
+    // For numerical stability, subtract max value before exponential
+    const max = input.max(this.dim, true);
+    const diff = input.sub(max);
+    const sumExp = diff.exp().sum(this.dim, true);
+    const logSm = diff.sub(sumExp.log());
+    return logSm;
+  }
+}

--- a/packages/web/src/nn/dropout.ts
+++ b/packages/web/src/nn/dropout.ts
@@ -1,0 +1,19 @@
+import { bernoulli, full } from "@/globals";
+import { Module } from "@/nn/module";
+import { Tensor } from "@/tensor";
+
+export class Dropout extends Module {
+  constructor(private p = 0.5) {
+    super();
+  }
+
+  forward(input: Tensor) {
+    if (!this.training || this.p === 0) {
+      return input;
+    }
+
+    const probs = full(input.size(), this.p, { device: input.device });
+    const mask = bernoulli(probs);
+    return input.mul(mask).affine(1 / (1 - this.p), 0);
+  }
+}

--- a/packages/web/src/nn/embedding.ts
+++ b/packages/web/src/nn/embedding.ts
@@ -1,0 +1,27 @@
+import { randn } from "@/core";
+import { Module } from "@/nn/module";
+import { Parameter } from "@/parameter";
+import { Tensor } from "@/tensor";
+
+export class Embedding extends Module {
+  weight: Parameter;
+  hiddenSize: number;
+  /**
+   * Create a new embedding module
+   * @param {number} numEmbeddings - Number of embeddings
+   * @param {number} embeddingDim - Embedding dimension
+   */
+  constructor(numEmbeddings: number, embeddingDim: number) {
+    super();
+    this.weight = new Parameter(randn([numEmbeddings, embeddingDim]));
+    this.hiddenSize = embeddingDim;
+  }
+
+  forward(input: Tensor) {
+    const finalDims = input.size();
+    finalDims.push(this.hiddenSize);
+    const indexes = input.flatten();
+    const values = this.weight.indexSelect(indexes, 0);
+    return values.view(finalDims);
+  }
+}

--- a/packages/web/src/nn/index.ts
+++ b/packages/web/src/nn/index.ts
@@ -1,0 +1,21 @@
+export { LogSoftmax } from "./activation";
+export { Dropout } from "./dropout";
+export { Embedding } from "./embedding";
+export { Linear } from "./linear";
+export { CrossEntropyLoss } from "./loss";
+export { Module, ModuleDict, ModuleList } from "./module";
+export { LayerNorm } from "./normalization";
+export {
+  ModuleScopeItem,
+  nameFromScope,
+  OptimizerParamGroupScopeItem,
+  OptimizerParamUpdateScopeItem,
+  OptimizerScopeItem,
+  ScopeItem,
+  tensorName,
+  tensorScopeStack,
+  track,
+  TrackedTensor,
+  trackOptimizerStep,
+  withScope,
+} from "./tracking";

--- a/packages/web/src/nn/linear.ts
+++ b/packages/web/src/nn/linear.ts
@@ -1,0 +1,42 @@
+import { randn, zeros } from "@/globals";
+import { Module } from "@/nn/module";
+import { Parameter } from "@/parameter";
+import { Tensor } from "@/tensor";
+
+export class Linear extends Module {
+  weight: Parameter;
+  bias?: Parameter;
+  /**
+   * Create a new linear module
+   * @param {number} inFeatures - Input features
+   * @param {number} outFeatures - Output features
+   * @param {boolean} bias - Whether to use bias
+   */
+  constructor(inFeatures: number, outFeatures: number, bias = true) {
+    super();
+    this.weight = new Parameter(randn([outFeatures, inFeatures]));
+
+    if (bias) {
+      this.bias = new Parameter(zeros([outFeatures]));
+    }
+  }
+
+  forward(input: Tensor) {
+    let w;
+    if (input.size().length === 4) {
+      w = this.weight.broadcastLeft([input.size(0), input.size(1)]);
+    } else if (input.size().length === 3) {
+      w = this.weight.broadcastLeft([input.size(0)]);
+    } else {
+      w = this.weight;
+    }
+
+    const x = input.matmul(w, false, true);
+
+    if (this.bias) {
+      return x.add(this.bias.cast(x.dtype()));
+    }
+
+    return x;
+  }
+}

--- a/packages/web/src/nn/loss.ts
+++ b/packages/web/src/nn/loss.ts
@@ -1,0 +1,121 @@
+import { float32, full, int32 } from "@/globals";
+import { LogSoftmax } from "@/nn/activation";
+import { Module } from "@/nn/module";
+import { Tensor } from "@/tensor";
+
+/**
+ * Configuration options for CrossEntropyLoss
+ * @interface CrossEntropyLossConfig
+ */
+interface CrossEntropyLossConfig {
+  /**
+   * Index to ignore in the target tensor
+   * @default -100
+   */
+  ignoreIndex?: number;
+
+  /**
+   * Specifies the reduction to apply to the output
+   * @default 'mean'
+   */
+  reduction?: "none" | "sum" | "mean";
+
+  /**
+   * Smoothing factor for label smoothing regularization
+   * @default 0.0
+   */
+  labelSmoothing?: number;
+}
+
+export class CrossEntropyLoss extends Module {
+  private ignoreIndex: number;
+  private reduction: "none" | "sum" | "mean";
+  private labelSmoothing: number;
+  private logSoftmax: LogSoftmax;
+
+  constructor(config: CrossEntropyLossConfig = {}) {
+    super();
+    this.ignoreIndex = config.ignoreIndex ?? -100;
+    this.reduction = config.reduction ?? "mean";
+    this.labelSmoothing = config.labelSmoothing ?? 0.0;
+    this.logSoftmax = new LogSoftmax(1);
+  }
+
+  forward(input: Tensor, target: Tensor): Tensor {
+    // Validate shapes
+    const inputShape = input.size();
+    const targetShape = target.size();
+
+    if (inputShape.length !== 2) {
+      throw new Error(
+        `CrossEntropyLoss: input must be rank-2 [batch_size, vocab_size], got ${inputShape}`,
+      );
+    }
+
+    if (targetShape.length !== 1) {
+      throw new Error(
+        `CrossEntropyLoss: target must be [batch_size], got ${targetShape}`,
+      );
+    }
+
+    const [batchSize, vocabSize] = inputShape;
+    const targetBatchSize = targetShape[0];
+
+    if (batchSize !== targetBatchSize) {
+      throw new Error(
+        `CrossEntropyLoss: batch size mismatch between input (${batchSize}) and target (${targetBatchSize})`,
+      );
+    }
+
+    // Apply log softmax to the input
+    const logProbs = this.logSoftmax.forward(input);
+
+    // Create mask for ignored indices
+    const mask = target
+      .ne(
+        full(targetShape, this.ignoreIndex, {
+          device: target.device,
+          dtype: int32,
+        }),
+      )
+      .cast(float32);
+
+    // Gather the negative log-prob for the correct classes
+    const nllGathered = logProbs.gather(target.unsqueeze(1), 1).mul(-1);
+
+    // Mask out ignored tokens
+    const nllMasked = nllGathered.mul(mask.unsqueeze(1));
+
+    // At this point, nllMasked has shape [batchSize, 1]. We squeeze it to get a per-sample loss.
+    const nllLossPerSample = nllMasked.squeeze(1); // shape: [batchSize]
+
+    // Compute final per-sample loss (without global normalization)
+    let finalLossPerSample = nllLossPerSample;
+
+    // If label smoothing is applied, compute the uniform loss per sample and combine.
+    if (this.labelSmoothing > 0) {
+      // Calculate uniform loss: average log probability over all classes for each sample.
+      const allProbsMasked = logProbs.mul(mask.unsqueeze(1));
+      const sumLogProbs = allProbsMasked.sum(1); // shape: [batchSize]
+      const uniformLossPerSample = sumLogProbs.mul(-1 / vocabSize);
+
+      // Combine with the nll loss using the smoothing factor.
+      finalLossPerSample = nllLossPerSample
+        .mul(1 - this.labelSmoothing)
+        .add(uniformLossPerSample.mul(this.labelSmoothing));
+    }
+
+    // Apply reduction according to the configuration.
+    if (this.reduction === "none") {
+      // Return the per-sample losses directly.
+      return finalLossPerSample;
+    } else if (this.reduction === "sum") {
+      // Sum up all per-sample losses.
+      return finalLossPerSample.sum();
+    } else {
+      // For "mean", average the sum of losses by the count of valid tokens.
+      const validCount = mask.sum();
+      return finalLossPerSample.sum().div(validCount);
+    }
+  }
+}

--- a/packages/web/src/nn/module.ts
+++ b/packages/web/src/nn/module.ts
@@ -1,0 +1,1138 @@
+import { Parameter } from "@/parameter";
+import { Tensor } from "@/tensor";
+import { RemovableHandle } from "@/utils";
+import { Tensor_wasm } from "@/wasm";
+
+import { ModuleScopeItem, ScopeItem, withScope } from "./tracking";
+
+// TODO(vinhowe): These implementations are not very good right now
+
+/**
+ * Buffer class to represent non-trainable tensors
+ * Buffers are tensors that do not require gradients for optimization during training.
+ * This is similar to torch.Tensor in PyTorch.
+ */
+export class Buffer {
+  data: Tensor;
+  persistent: boolean;
+
+  constructor(data: Tensor, persistent: boolean = true) {
+    this.data = data;
+    this.persistent = persistent;
+  }
+}
+
+/**
+ * Module class to represent neural network modules
+ * Modules are the building blocks of neural networks.
+ * They can contain parameters, buffers, and other modules.
+ * This is similar to torch.nn.Module in PyTorch.
+ */
+export class Module<Input = unknown, Output = unknown> {
+  training: boolean;
+  protected _parameters: Record<string, Parameter>;
+  protected _buffers: Record<string, Buffer>;
+  protected _modules: Record<string, Module<unknown, unknown>>;
+  protected _nonPersistentBuffersSet: Set<string>;
+  protected _forwardPreHooks: Map<
+    number,
+    (module: Module<Input, Output>, inputs: Input) => Input | undefined
+  >;
+  protected _forwardHooks: Map<
+    number,
+    (
+      module: Module<Input, Output>,
+      inputs: Input,
+      output: Output,
+    ) => Output | undefined
+  >;
+  protected _nextHookId: number;
+  // Name of the property on the parent module that this module is assigned to
+  // Helps us keep track of module scopes
+  nameOnParent: string | undefined;
+  scope: ScopeItem[] | undefined;
+
+  constructor() {
+    this.training = true;
+    this._parameters = {};
+    this._buffers = {};
+    this._modules = {};
+    this._nonPersistentBuffersSet = new Set<string>();
+    this._nextHookId = 0;
+    this._forwardPreHooks = new Map();
+    this._forwardHooks = new Map();
+    this.scope = [
+      {
+        type: "module",
+        module: this as Module<unknown, unknown>,
+        name: undefined,
+      },
+    ];
+
+    // Use Proxy to intercept property assignments and access
+    return new Proxy(this, {
+      set: (
+        target: Module<Input, Output>,
+        prop: string | symbol,
+        value: unknown,
+      ): boolean => {
+        // Allow direct setting of internal properties
+        if (typeof prop === "symbol" || prop.toString().startsWith("_")) {
+          (target as unknown as Record<string, unknown>)[prop as string] =
+            value;
+          return true;
+        }
+
+        // Handle attribute setting through _setAttr
+        return target._setAttr(prop.toString(), value);
+      },
+
+      get: (
+        target: Module<Input, Output>,
+        prop: string | symbol,
+        receiver: unknown,
+      ): unknown => {
+        // Handle hooks
+        if (prop === "forward" && typeof target.forward === "function") {
+          return function (...args: unknown[]) {
+            // Apply pre-hooks
+            let hookInput = args;
+            for (const hook of target._forwardPreHooks.values()) {
+              const result = hook(target, args as Input);
+              if (result !== undefined) {
+                hookInput = Array.isArray(result) ? result : [result];
+              }
+            }
+
+            const output = withScope(
+              target.scope ?? [],
+              () => Reflect.apply(target.forward, receiver, hookInput),
+              { replace: true },
+            );
+
+            // Apply post-hooks
+            let hookOutput = output;
+            for (const hook of target._forwardHooks.values()) {
+              const result = hook(target, hookInput as Input, hookOutput);
+              if (result !== undefined) {
+                hookOutput = result;
+              }
+            }
+
+            return hookOutput;
+          };
+        }
+
+        // Return methods and internal properties directly
+        if (
+          prop in target ||
+          typeof prop === "symbol" ||
+          prop.toString().startsWith("_")
+        ) {
+          return (target as unknown as Record<string, unknown>)[prop as string];
+        }
+
+        // Return registered parameters, buffers, or modules
+        const propStr = prop.toString();
+        if (propStr in target._parameters) return target._parameters[propStr];
+        if (propStr in target._buffers) return target._buffers[propStr];
+        if (propStr in target._modules) return target._modules[propStr];
+
+        return undefined;
+      },
+    }) as Module<Input, Output>;
+  }
+
+  _setAttr(name: string, value: unknown): boolean {
+    // Helper function to remove attribute from various collections
+    const removeFrom = (
+      ...containers: Array<Record<string, unknown> | Set<string> | object>
+    ): void => {
+      for (const container of containers) {
+        if (container instanceof Set) {
+          container.delete(name);
+        } else if (container instanceof Object && name in container) {
+          delete (container as Record<string, unknown>)[name];
+        }
+      }
+    };
+
+    // Handle Parameter assignment
+    if (Parameter._unwrap(value as Parameter) instanceof Tensor_wasm) {
+      if (!this._parameters) {
+        throw new Error(
+          "Cannot assign parameters before Module constructor call",
+        );
+      }
+      removeFrom(
+        this,
+        this._buffers,
+        this._modules,
+        this._nonPersistentBuffersSet,
+      );
+      this.registerParameter(name, value as Parameter);
+    }
+    // Handle existing Parameter being replaced
+    else if (this._parameters && name in this._parameters) {
+      if (value !== null) {
+        throw new TypeError(
+          `Cannot assign '${value?.constructor?.name || typeof value}' as parameter '${name}' ` +
+            "(Parameter or null expected)",
+        );
+      }
+      this.registerParameter(name, value);
+    }
+    // Handle Module assignment
+    else if (value instanceof Module) {
+      if (!this._modules) {
+        throw new Error("Cannot assign module before Module constructor call");
+      }
+      removeFrom(
+        this,
+        this._parameters,
+        this._buffers,
+        this._nonPersistentBuffersSet,
+      );
+      this.addModule(name, value);
+    }
+    // Handle existing Module being replaced
+    else if (this._modules && name in this._modules) {
+      if (value !== null) {
+        throw new TypeError(
+          `Cannot assign '${value?.constructor?.name || typeof value}' as child module '${name}' ` +
+            "(Module or null expected)",
+        );
+      }
+      this.addModule(name, value);
+    }
+    // Handle Buffer or existing Buffer being replaced
+    else if (
+      value instanceof Buffer ||
+      (this._buffers && name in this._buffers)
+    ) {
+      if (value !== null && !(value instanceof Buffer)) {
+        throw new TypeError(
+          `Cannot assign '${value?.constructor?.name || typeof value}' as buffer '${name}' ` +
+            "(Buffer or null expected)",
+        );
+      }
+      const persistent =
+        value instanceof Buffer
+          ? value.persistent
+          : !this._nonPersistentBuffersSet.has(name);
+      this.registerBuffer(name, value, persistent);
+    }
+    // Handle regular attribute
+    else {
+      (this as unknown as Record<string, unknown>)[name] = value;
+    }
+
+    return true;
+  }
+
+  registerParameter(
+    name: string,
+    param: Parameter | null,
+  ): Module<Input, Output> {
+    if (param !== null && !(Parameter._unwrap(param) instanceof Tensor_wasm)) {
+      throw new TypeError(
+        `Cannot assign '${(param as unknown)?.constructor?.name || typeof param}' as parameter '${name}'`,
+      );
+    }
+
+    // Remove any existing attribute
+    delete (this as unknown as Record<string, unknown>)[name];
+
+    if (param === null) {
+      delete this._parameters[name];
+    } else {
+      this._parameters[name] = param;
+    }
+
+    (param as Parameter).scope = [...(this.scope || [])];
+    (param as Parameter).nameOnParent = name;
+    return this;
+  }
+
+  registerBuffer(
+    name: string,
+    buffer: Buffer | null,
+    persistent: boolean = true,
+  ): Module<Input, Output> {
+    if (buffer !== null && !(buffer instanceof Buffer)) {
+      throw new TypeError(
+        `Cannot assign '${(buffer as unknown)?.constructor?.name || typeof buffer}' as buffer '${name}'`,
+      );
+    }
+
+    // Remove any existing attribute
+    delete (this as unknown as Record<string, unknown>)[name];
+
+    if (buffer === null) {
+      delete this._buffers[name];
+      if (this._nonPersistentBuffersSet.has(name)) {
+        this._nonPersistentBuffersSet.delete(name);
+      }
+    } else {
+      this._buffers[name] = buffer;
+      if (!persistent) {
+        this._nonPersistentBuffersSet.add(name);
+      } else if (this._nonPersistentBuffersSet.has(name)) {
+        this._nonPersistentBuffersSet.delete(name);
+      }
+    }
+
+    (buffer as Buffer).data.scope = [...(this.scope || [])];
+    (buffer as Buffer).data.nameOnParent = name;
+    return this;
+  }
+
+  /**
+   * Add a child module to the current module.
+   *
+   * The module can be accessed as an attribute using the given name.
+   *
+   * @param name - name of the child module. The child module can be accessed from this module using the given name
+   * @param module - child module to be added to the module.
+   */
+  addModule<SubmoduleInput, SubmoduleOutput>(
+    name: string,
+    module: Module<SubmoduleInput, SubmoduleOutput> | null,
+  ): Module<Input, Output> {
+    if (module !== null && !(module instanceof Module)) {
+      throw new Error(
+        `${(module as unknown)?.constructor?.name || typeof module} is not a Module`,
+      );
+    } else if (typeof name !== "string") {
+      throw new Error(`module name should be a string. Got ${typeof name}`);
+    } else if (name in this && !(name in this._modules)) {
+      throw new Error(`attribute '${name}' already exists`);
+    } else if (name.includes(".")) {
+      throw new Error(`module name can't contain ".", got: ${name}`);
+    } else if (name === "") {
+      throw new Error('module name can\'t be empty string ""');
+    }
+
+    this._modules[name] = module as Module<unknown, unknown>;
+    (module!.scope![module!.scope!.length - 1] as ModuleScopeItem).name = name;
+    const thisScope = this.scope || [];
+    module?.parameters().forEach((param) => {
+      (param as Parameter).scope = [...thisScope, ...(param.scope ?? [])];
+    });
+    module?.buffers().forEach((buf) => {
+      (buf as Buffer).data.scope = [...thisScope, ...(buf.data.scope ?? [])];
+    });
+    module?.modules().forEach((mod) => {
+      (mod as Module<unknown, unknown>).scope = [
+        ...thisScope,
+        ...(mod.scope ?? []),
+      ];
+    });
+    return this;
+  }
+
+  /**
+   * Helper method that returns an iterator over named members of the module.
+   */
+  private *_namedMembers<SubmoduleInput, SubmoduleOutput, MemberType>(
+    getMembersFn: (
+      module: Module<SubmoduleInput, SubmoduleOutput>,
+    ) => Iterable<[string, MemberType]>,
+    prefix: string = "",
+    recurse: boolean = true,
+    removeDuplicate: boolean = true,
+    memo: Set<MemberType> = new Set(),
+  ): Generator<[string, MemberType]> {
+    // Get members from this module
+    for (const [name, item] of getMembersFn(
+      this as unknown as Module<SubmoduleInput, SubmoduleOutput>,
+    )) {
+      if (item !== null) {
+        if (removeDuplicate && memo.has(item)) {
+          continue;
+        }
+        memo.add(item);
+        yield [prefix + (prefix ? "." : "") + name, item];
+      }
+    }
+
+    // Recursively get members from child modules
+    if (recurse) {
+      for (const [name, module] of Object.entries(this._modules)) {
+        if (module === null) {
+          continue;
+        }
+
+        const submodulePrefix = prefix + (prefix ? "." : "") + name;
+
+        // Create a generator from the child module's named members
+        const submodule_gen = module._namedMembers(
+          getMembersFn,
+          submodulePrefix,
+          recurse,
+          removeDuplicate,
+          memo,
+        );
+
+        // Yield all elements from the submodule generator
+        yield* submodule_gen;
+      }
+    }
+  }
+
+  /**
+   * Return an iterator over module parameters.
+   *
+   * @param recurse - If true, recurses into child modules
+   */
+  *parametersIter(recurse: boolean = true): Generator<Parameter> {
+    for (const [, param] of this.namedParametersIter("", recurse)) {
+      yield param;
+    }
+  }
+
+  /**
+   * Return an array of module parameters.
+   *
+   * @param recurse - If true, recurses into child modules
+   */
+  parameters(recurse: boolean = true): Parameter[] {
+    return Array.from(this.parametersIter(recurse));
+  }
+
+  /**
+   * Return an iterator over named module parameters.
+   *
+   * @param prefix - Prefix to prepend to all parameter names
+   * @param recurse - If true, recurses into child modules
+   * @param remove_duplicate - If true, removes duplicate parameters
+   */
+  *namedParametersIter(
+    prefix: string = "",
+    recurse: boolean = true,
+    remove_duplicate: boolean = true,
+  ): Generator<[string, Parameter]> {
+    const gen = this._namedMembers<unknown, unknown, Parameter>(
+      (module) => Object.entries(module._parameters),
+      prefix,
+      recurse,
+      remove_duplicate,
+    );
+
+    yield* gen;
+  }
+
+  /**
+   * Return an array of named module parameters.
+   *
+   * @param prefix - Prefix to prepend to all parameter names
+   * @param recurse - If true, recurses into child modules
+   * @param remove_duplicate - If true, removes duplicate parameters
+   */
+  namedParameters(
+    prefix: string = "",
+    recurse: boolean = true,
+    remove_duplicate: boolean = true,
+  ): Array<[string, Parameter]> {
+    return Array.from(
+      this.namedParametersIter(prefix, recurse, remove_duplicate),
+    );
+  }
+
+  /**
+   * Return an iterator over module buffers.
+   *
+   * @param recurse - If true, recurses into child modules
+   */
+  *buffersIter(recurse: boolean = true): Generator<Buffer> {
+    for (const [, buf] of this.namedBuffersIter("", recurse)) {
+      yield buf;
+    }
+  }
+
+  /**
+   * Return an array of module buffers.
+   *
+   * @param recurse - If true, recurses into child modules
+   */
+  buffers(recurse: boolean = true): Buffer[] {
+    return Array.from(this.buffersIter(recurse));
+  }
+
+  /**
+   * Return an iterator over named module buffers.
+   *
+   * @param prefix - Prefix to prepend to all buffer names
+   * @param recurse - If true, recurses into child modules
+   * @param remove_duplicate - If true, removes duplicate buffers
+   */
+  *namedBuffersIter(
+    prefix: string = "",
+    recurse: boolean = true,
+    remove_duplicate: boolean = true,
+  ): Generator<[string, Buffer]> {
+    const gen = this._namedMembers<unknown, unknown, Buffer>(
+      (module) => Object.entries(module._buffers),
+      prefix,
+      recurse,
+      remove_duplicate,
+    );
+
+    yield* gen;
+  }
+
+  /**
+   * Return an array of named module buffers.
+   *
+   * @param prefix - Prefix to prepend to all buffer names
+   * @param recurse - If true, recurses into child modules
+   * @param remove_duplicate - If true, removes duplicate buffers
+   */
+  namedBuffers(
+    prefix: string = "",
+    recurse: boolean = true,
+    remove_duplicate: boolean = true,
+  ): Array<[string, Buffer]> {
+    return Array.from(this.namedBuffersIter(prefix, recurse, remove_duplicate));
+  }
+
+  /**
+   * Return an iterator over immediate children modules.
+   */
+  *childrenIter(): Generator<Module<unknown, unknown>> {
+    for (const [, module] of this.namedChildrenIter()) {
+      yield module;
+    }
+  }
+
+  /**
+   * Return an array of immediate children modules.
+   */
+  children(): Module<unknown, unknown>[] {
+    return Array.from(this.childrenIter());
+  }
+
+  /**
+   * Return an iterator over immediate named children modules.
+   */
+  *namedChildrenIter(): Generator<[string, Module]> {
+    const memo = new Set<Module>();
+
+    for (const [name, module] of Object.entries(this._modules)) {
+      if (module !== null && !memo.has(module)) {
+        memo.add(module);
+        yield [name, module];
+      }
+    }
+  }
+
+  /**
+   * Return an array of immediate named children modules.
+   */
+  namedChildren(): Array<[string, Module]> {
+    return Array.from(this.namedChildrenIter());
+  }
+
+  /**
+   * Return an iterator over all modules in the network.
+   */
+  *modulesIter(): Generator<Module> {
+    for (const [, module] of this.namedModulesIter()) {
+      yield module;
+    }
+  }
+
+  /**
+   * Return an array of all modules in the network.
+   */
+  modules(): Module[] {
+    return Array.from(this.modulesIter());
+  }
+
+  /**
+   * Return an iterator over all named modules in the network.
+   *
+   * @param memo - Set used to track already seen modules
+   * @param prefix - Prefix to prepend to all module names
+   * @param remove_duplicate - If true, removes duplicate modules
+   */
+  *namedModulesIter(
+    memo: Set<Module> = new Set<Module>(),
+    prefix: string = "",
+    remove_duplicate: boolean = true,
+  ): Generator<[string, Module]> {
+    if (!memo.has(this as unknown as Module) || !remove_duplicate) {
+      if (remove_duplicate) {
+        memo.add(this as unknown as Module);
+      }
+
+      yield [prefix, this as unknown as Module];
+
+      for (const [name, module] of Object.entries(this._modules)) {
+        if (module === null) {
+          continue;
+        }
+
+        const submodulePrefix = prefix + (prefix ? "." : "") + name;
+
+        // Get generator from submodule's named modules
+        yield* module.namedModulesIter(memo, submodulePrefix, remove_duplicate);
+      }
+    }
+  }
+
+  /**
+   * Return an array of all named modules in the network.
+   *
+   * @param memo - Set used to track already seen modules
+   * @param prefix - Prefix to prepend to all module names
+   * @param remove_duplicate - If true, removes duplicate modules
+   */
+  namedModules(
+    memo: Set<Module> = new Set<Module>(),
+    prefix: string = "",
+    remove_duplicate: boolean = true,
+  ): Array<[string, Module]> {
+    return Array.from(this.namedModulesIter(memo, prefix, remove_duplicate));
+  }
+
+  /**
+   * Set the module in training mode.
+   *
+   * @param mode - Whether to set training mode (true) or evaluation mode (false)
+   */
+  train(mode: boolean = true): Module {
+    if (typeof mode !== "boolean") {
+      throw new TypeError("Training mode is expected to be boolean");
+    }
+
+    this.training = mode;
+
+    for (const module of this.children()) {
+      module.train(mode);
+    }
+
+    return this as unknown as Module;
+  }
+
+  /**
+   * Set the module in evaluation mode (equivalent to train(false)).
+   */
+  eval(): Module {
+    return this.train(false);
+  }
+
+  /**
+   * Return state dictionary containing parameters and persistent buffers.
+   */
+  stateDict(): Record<string, Parameter | Buffer> {
+    const state: Record<string, Parameter | Buffer> = {};
+
+    // Add parameters
+    for (const [name, param] of this.namedParameters()) {
+      if (param !== null) {
+        state[name] = param;
+      }
+    }
+
+    // Add persistent buffers (exclude those in _nonPersistentBuffersSet)
+    for (const [name, buf] of this.namedBuffers()) {
+      if (buf !== null && !this._nonPersistentBuffersSet.has(name)) {
+        state[name] = buf;
+      }
+    }
+
+    return state;
+  }
+
+  /**
+   * Registers a forward pre-hook which will be called before forward is called.
+   *
+   * @param hook - Function taking module and input arguments, returning modified input or undefined
+   * @returns A handle that can be used to remove the hook
+   */
+  registerForwardPreHook(
+    hook: (module: Module<Input, Output>, inputs: Input) => Input | undefined,
+  ): RemovableHandle {
+    const handle = new RemovableHandle(this._forwardPreHooks);
+    this._forwardPreHooks.set(handle.id, hook);
+    return handle;
+  }
+
+  /**
+   * Registers a forward hook which will be called after forward is called.
+   *
+   * @param hook - Function taking module, input and output arguments, returning modified output or undefined
+   * @returns A handle that can be used to remove the hook
+   */
+  registerForwardHook(
+    hook: (
+      module: Module<Input, Output>,
+      inputs: Input,
+      output: Output,
+    ) => Output | undefined,
+  ): RemovableHandle {
+    const handle = new RemovableHandle(this._forwardHooks);
+    this._forwardHooks.set(handle.id, hook);
+    return handle;
+  }
+
+  /**
+   * Abstract method that should be implemented by subclasses to define the
+   * forward pass
+   *
+   * @param input - The input to the module
+   * @returns The output from the module
+   */
+  // @ts-expect-error - This is an abstract method that will be implemented by
+  // subclasses
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  forward(...input: Input): Output {
+    throw new Error("Subclasses must implement the forward method");
+  }
+}
+
+/**
+ * ModuleList container for a sequence of modules
+ * Modules can be added as ordered members of the ModuleList.
+ * ModuleList can be indexed like an array to access contained modules.
+ * This is similar to torch.nn.ModuleList in PyTorch.
+ */
+export class ModuleList<Input = unknown, Output = unknown> extends Module<
+  Input,
+  Output
+> {
+  private _modules_list: Module<Input, Output>[];
+  private _proxy: ModuleList<Input, Output>;
+  [key: number]: Module<Input, Output>;
+
+  constructor(modules: Module<Input, Output>[] = []) {
+    super();
+    this._modules_list = [];
+
+    // Add modules if provided in constructor
+    if (modules && modules.length > 0) {
+      for (let i = 0; i < modules.length; i++) {
+        this.append(modules[i]);
+      }
+    }
+
+    // Create a proxy to allow array-like indexing
+    this._proxy = new Proxy(this, {
+      get: (
+        target: ModuleList<Input, Output>,
+        prop: string | symbol,
+      ): unknown => {
+        // Forward numeric indices and string numeric indices to at()
+        if (typeof prop === "string" && /^\d+$/.test(prop)) {
+          return target.at(parseInt(prop, 10));
+        } else if (typeof prop === "number") {
+          return target.at(prop);
+        }
+
+        // Forward everything else to the target
+        return Reflect.get(target, prop);
+      },
+      set: (
+        target: ModuleList<Input, Output>,
+        prop: string | symbol,
+        value: unknown,
+      ): boolean => {
+        // Handle numeric indices and string numeric indices
+        if (
+          typeof prop === "string" &&
+          /^\d+$/.test(prop) &&
+          value instanceof Module
+        ) {
+          const index = parseInt(prop, 10);
+          if (index >= 0 && index < target.length) {
+            // Set using the set method
+            target.set(index, value);
+            return true;
+          }
+        }
+
+        // Default behavior for other properties
+        return Reflect.set(target, prop, value);
+      },
+    });
+  }
+
+  /**
+   * Returns the proxy version of this ModuleList for array-like indexing
+   */
+  valueOf(): unknown {
+    return this._proxy;
+  }
+
+  /**
+   * Appends a module to the ModuleList
+   *
+   * @param module - Module to append
+   * @returns The ModuleList instance for chaining
+   */
+  append(module: Module<Input, Output>): ModuleList<Input, Output> {
+    const idx = this._modules_list.length;
+    this.addModule(idx.toString(), module);
+    this._modules_list.push(module);
+    return this;
+  }
+
+  /**
+   * Extends the ModuleList with an iterable of modules
+   *
+   * @param modules - Iterable of modules to add
+   * @returns The ModuleList instance for chaining
+   */
+  extend(modules: Iterable<Module<Input, Output>>): ModuleList<Input, Output> {
+    for (const module of modules) {
+      this.append(module);
+    }
+    return this;
+  }
+
+  /**
+   * Insert a module at a specific position
+   *
+   * @param index - Position to insert the module
+   * @param module - Module to insert
+   * @returns The ModuleList instance for chaining
+   */
+  insert(
+    index: number,
+    module: Module<Input, Output>,
+  ): ModuleList<Input, Output> {
+    if (index < 0) {
+      index = Math.max(0, this._modules_list.length + index + 1);
+    }
+
+    // Insert the module in our list
+    this._modules_list.splice(index, 0, module);
+
+    // Re-register all modules with updated indices
+    this._recreateModules();
+
+    return this;
+  }
+
+  /**
+   * Remove the first occurrence of a specific module
+   *
+   * @param module - Module to remove
+   * @returns The ModuleList instance for chaining
+   */
+  remove(module: Module<Input, Output>): ModuleList<Input, Output> {
+    const index = this._modules_list.indexOf(module);
+    if (index !== -1) {
+      this._modules_list.splice(index, 1);
+      // Re-register all modules with updated indices
+      this._recreateModules();
+    }
+    return this;
+  }
+
+  /**
+   * Clear all modules from the ModuleList
+   *
+   * @returns The ModuleList instance for chaining
+   */
+  clear(): ModuleList<Input, Output> {
+    this._modules_list = [];
+    // Get all registered module keys using named modules iterator
+    const moduleKeys = Array.from(this.namedChildrenIter()).map(([key]) => key);
+    for (const key of moduleKeys) {
+      this.addModule(key, null);
+    }
+    return this;
+  }
+
+  /**
+   * Get the number of modules in the ModuleList
+   */
+  get length(): number {
+    return this._modules_list.length;
+  }
+
+  /**
+   * Access a module by index
+   *
+   * @param index - Index of the module to retrieve
+   * @returns The module at the specified index
+   */
+  at(index: number): Module<Input, Output> | undefined {
+    if (index < 0) {
+      index = this._modules_list.length + index;
+    }
+    return this._modules_list[index];
+  }
+
+  /**
+   * Set a module at a specific index
+   *
+   * @param index - Index where to set the module
+   * @param module - Module to set at the index
+   * @returns The ModuleList instance for chaining
+   */
+  set(index: number, module: Module<Input, Output>): ModuleList<Input, Output> {
+    if (index < 0) {
+      index = this._modules_list.length + index;
+    }
+
+    if (index >= 0 && index < this._modules_list.length) {
+      // Remove old module registration
+      this.addModule(index.toString(), null);
+      // Add new module
+      this.addModule(index.toString(), module);
+      // Update in the array
+      this._modules_list[index] = module;
+    } else if (index === this._modules_list.length) {
+      // If appending to the end, use append
+      this.append(module);
+    } else {
+      throw new Error("Index out of bounds");
+    }
+
+    return this;
+  }
+
+  /**
+   * Helper method to recreate the numbered module references after insertion or deletion
+   * @private
+   */
+  private _recreateModules(): void {
+    // Get all registered module keys using named modules iterator
+    const moduleKeys = Array.from(this.namedChildrenIter()).map(([key]) => key);
+
+    // Clear existing numbered modules
+    for (const key of moduleKeys) {
+      this.addModule(key, null);
+    }
+
+    // Re-add all modules with correct indices
+    for (let i = 0; i < this._modules_list.length; i++) {
+      this.addModule(i.toString(), this._modules_list[i]);
+    }
+  }
+
+  /**
+   * Array-like indexing
+   *
+   * @param index - Index to access
+   * @returns The module at the specified index
+   */
+  get(index: number): Module<Input, Output> | undefined {
+    return this.at(index);
+  }
+
+  /**
+   * Get the list of modules in the ModuleList
+   */
+  get list(): Module<Input, Output>[] {
+    return this._modules_list;
+  }
+
+  /**
+   * Direct access to the ModuleList, using the key as a property
+   */
+  [Symbol.toPrimitive](_hint: number): ModuleList<Input, Output> {
+    return this._proxy;
+  }
+}
+
+/**
+ * ModuleDict container for storing modules by name
+ * Modules can be added to the ModuleDict with a name as key.
+ * ModuleDict can be accessed like an object to retrieve contained modules.
+ * This is similar to torch.nn.ModuleDict in PyTorch.
+ */
+export class ModuleDict<T extends Record<string, Module>> extends Module {
+  private _proxy: ModuleDict<T>;
+
+  constructor(modules: T = {} as T) {
+    super();
+
+    // Add modules if provided in constructor
+    if (modules && Object.keys(modules).length > 0) {
+      for (const [key, module] of Object.entries(modules)) {
+        this.update({ [key]: module });
+      }
+    }
+
+    // Create a proxy to allow object-like access
+    this._proxy = new Proxy(this, {
+      get: (target: ModuleDict<T>, prop: string | symbol): unknown => {
+        // Forward string properties to get()
+        if (
+          typeof prop === "string" &&
+          Object.prototype.hasOwnProperty.call(target._modules, prop)
+        ) {
+          return target.get(prop);
+        }
+
+        // Forward everything else to the target
+        return Reflect.get(target, prop);
+      },
+      set: (
+        target: ModuleDict<T>,
+        prop: string | symbol,
+        value: unknown,
+      ): boolean => {
+        // Handle string properties as modules
+        if (
+          typeof prop === "string" &&
+          !prop.startsWith("_") &&
+          value instanceof Module
+        ) {
+          target.set(prop, value);
+          return true;
+        }
+
+        // Default behavior for other properties
+        return Reflect.set(target, prop, value);
+      },
+    });
+  }
+
+  /**
+   * Returns the proxy version of this ModuleDict for object-like access
+   */
+  valueOf(): ModuleDict<T> {
+    return this._proxy;
+  }
+
+  /**
+   * Add a module to the ModuleDict
+   *
+   * @param key - Key for the module
+   * @param module - Module to add
+   * @returns The ModuleDict instance for chaining
+   */
+  set(key: string, module: Module): ModuleDict<T> {
+    if (typeof key !== "string") {
+      throw new TypeError(`Key must be a string, got ${typeof key}`);
+    }
+
+    // Register module with the Module system
+    this.addModule(key, module);
+
+    // Keep track in our map
+    this._modules[key] = module;
+
+    return this;
+  }
+
+  /**
+   * Update the ModuleDict with entries from another mapping
+   *
+   * @param modules - Object with module mappings to add
+   * @returns The ModuleDict instance for chaining
+   */
+  update(modules: Record<string, Module>): ModuleDict<T> {
+    for (const [key, module] of Object.entries(modules)) {
+      this.set(key, module);
+    }
+    return this;
+  }
+
+  /**
+   * Get a module by key
+   *
+   * @param key - Key of the module to retrieve
+   * @returns The module with the specified key or undefined if not found
+   */
+  get(key: string): Module {
+    return this._modules?.[key];
+  }
+
+  /**
+   * Check if the ModuleDict contains a module with the specified key
+   *
+   * @param key - Key to check
+   * @returns True if the key exists, false otherwise
+   */
+  has(key: string): boolean {
+    return Object.prototype.hasOwnProperty.call(this._modules, key) ?? false;
+  }
+
+  /**
+   * Remove a module by key
+   *
+   * @param key - Key of the module to remove
+   * @returns The ModuleDict instance for chaining
+   */
+  delete(key: string): ModuleDict<T> {
+    if (Object.prototype.hasOwnProperty.call(this._modules, key)) {
+      // Remove from Module system
+      this.addModule(key, null);
+
+      // Remove from our map
+      delete this._modules[key];
+    }
+    return this;
+  }
+
+  /**
+   * Clear all modules from the ModuleDict
+   *
+   * @returns The ModuleDict instance for chaining
+   */
+  clear(): ModuleDict<T> {
+    // Get all keys
+    const keys = Object.keys(this._modules);
+
+    // Remove all modules
+    for (const key of keys) {
+      this.delete(key);
+    }
+
+    return this;
+  }
+
+  /**
+   * Get all keys in the ModuleDict
+   *
+   * @returns Array of keys
+   */
+  keys(): string[] {
+    return Object.keys(this._modules);
+  }
+
+  /**
+   * Get all values (modules) in the ModuleDict
+   *
+   * @returns Array of modules
+   */
+  values(): Module[] {
+    return Object.values(this._modules) as Module[];
+  }
+
+  /**
+   * Get all entries in the ModuleDict
+   *
+   * @returns Array of [key, module] pairs
+   */
+  entries(): Array<[string, Module]> {
+    return Object.entries(this._modules) as Array<[string, Module]>;
+  }
+
+  /**
+   * Get the number of modules in the ModuleDict
+   */
+  get length(): number {
+    return Object.keys(this._modules).length;
+  }
+
+  /**
+   * Iterate over the keys of the ModuleDict
+   */
+  *[Symbol.iterator](): IterableIterator<string> {
+    yield* Object.keys(this._modules);
+  }
+
+  /**
+   * Get the dictionary of modules in the ModuleDict
+   */
+  get dict(): T {
+    return this._modules as T;
+  }
+}

--- a/packages/web/src/nn/moduleUtils.ts
+++ b/packages/web/src/nn/moduleUtils.ts
@@ -1,0 +1,17 @@
+import { Module } from "@/nn/module";
+import { Tensor } from "@/tensor";
+
+export function debugBufferHook<Input>(
+  module: Module<Input, Tensor>,
+): Promise<Tensor> {
+  const promise = new Promise<Tensor>((resolve) => {
+    const hook = module.registerForwardHook(
+      (_module, _input: Input, output: Tensor) => {
+        resolve(output.debugTensor());
+        hook.remove();
+        return output;
+      },
+    );
+  });
+  return promise;
+}

--- a/packages/web/src/nn/normalization.ts
+++ b/packages/web/src/nn/normalization.ts
@@ -1,0 +1,19 @@
+import { ones, zeros } from "@/globals";
+import { Module } from "@/nn/module";
+import { Parameter } from "@/parameter";
+import { Tensor } from "@/tensor";
+
+export class LayerNorm extends Module {
+  weight: Parameter;
+  bias: Parameter;
+
+  constructor(normalizedShape: number, private eps = 1e-5) {
+    super();
+    this.weight = new Parameter(ones([normalizedShape]));
+    this.bias = new Parameter(zeros([normalizedShape]));
+  }
+
+  forward(input: Tensor) {
+    return input.layerNorm(this.weight, this.bias, this.eps);
+  }
+}

--- a/packages/web/src/nn/tracking.ts
+++ b/packages/web/src/nn/tracking.ts
@@ -1,0 +1,175 @@
+import { Module } from "@/nn/module";
+import { Optimizer, ParamGroup } from "@/optim";
+import { Parameter } from "@/parameter";
+import { OpDescription, Tensor } from "@/tensor";
+
+export interface BaseScopeItem {
+  type:
+    | "module"
+    | "optimizer"
+    | "optimizer-param-group"
+    | "optimizer-param-update";
+  name: string | undefined;
+}
+
+export interface ModuleScopeItem extends BaseScopeItem {
+  type: "module";
+  module: Module<unknown, unknown>;
+}
+
+export interface OptimizerScopeItem extends BaseScopeItem {
+  type: "optimizer";
+  optimizer: Optimizer;
+}
+
+export interface OptimizerParamGroupScopeItem extends BaseScopeItem {
+  type: "optimizer-param-group";
+  optimizer: Optimizer;
+  paramGroup: ParamGroup;
+}
+
+export interface OptimizerParamUpdateScopeItem extends BaseScopeItem {
+  type: "optimizer-param-update";
+  optimizer: Optimizer;
+  parameter: Parameter;
+}
+
+export type ScopeItem =
+  | ModuleScopeItem
+  | OptimizerScopeItem
+  | OptimizerParamGroupScopeItem
+  | OptimizerParamUpdateScopeItem;
+
+export const tensorScopeStack: ScopeItem[] = [];
+
+interface TrackState {
+  stack: TrackedTensor[];
+  alreadyTracked: Set<number>;
+}
+
+export const trackStacks: Record<number, TrackState> = {};
+
+export interface TrackedTensor {
+  id: number;
+  op: OpDescription;
+  shape: number[];
+  srcIds: number[];
+  nameOnParent: string | undefined;
+  scope: ScopeItem[] | undefined;
+  tensor: Tensor | undefined;
+  debugTensor: Tensor | undefined;
+  dependency: boolean;
+}
+
+export interface TensorTrackOptions {
+  dependency?: boolean;
+}
+
+export function trackTensor(tensor: Tensor, options?: TensorTrackOptions) {
+  const { dependency = false } = options ?? {};
+
+  for (const stackId in trackStacks) {
+    const id = tensor.id();
+    if (trackStacks[stackId].alreadyTracked.has(id)) {
+      continue;
+    }
+    trackStacks[stackId].stack.push({
+      id,
+      op: tensor.op(),
+      shape: tensor.shape,
+      srcIds: tensor.srcIds(),
+      nameOnParent: tensor.nameOnParent,
+      scope: tensor.scope,
+      // This presumably breaks any non-explicit inplacing, which makes
+      // observing inplacing storage patterns difficult.
+      tensor: tensor,
+      // tensor: tensor.requiresGrad() ? tensor : undefined,
+      debugTensor: tensor.debugTensor(),
+      dependency,
+    });
+    trackStacks[stackId].alreadyTracked.add(id);
+  }
+  return tensor;
+}
+
+export function trackTensors(tensors: Tensor[], options?: TensorTrackOptions) {
+  const { dependency = false } = options ?? {};
+  for (const tensor of tensors) {
+    trackTensor(tensor, { dependency });
+  }
+}
+
+export interface WithScopeOptions {
+  replace?: boolean;
+}
+
+export function withScope<T>(
+  scope: ScopeItem[] | ((scope: ScopeItem[]) => ScopeItem[]),
+  f: () => T,
+  options: WithScopeOptions = {},
+): T {
+  const { replace = false } = options;
+  const originalScope = [...tensorScopeStack];
+  const newScope =
+    typeof scope === "function" ? scope(tensorScopeStack) : scope;
+  if (replace) {
+    tensorScopeStack.length = 0;
+  }
+  tensorScopeStack.push(...newScope);
+  try {
+    return f();
+  } finally {
+    tensorScopeStack.length = 0;
+    tensorScopeStack.push(...originalScope);
+  }
+}
+
+export function nameFromScope(scope: ScopeItem[]) {
+  return (
+    scope
+      .map((item) => (item.name?.includes(".") ? `[${item.name}]` : item.name))
+      .join(".") ?? "."
+  );
+}
+
+export function tensorName(tensor: Tensor) {
+  return (
+    nameFromScope(tensor.scope ?? []) +
+    (tensor.nameOnParent ? `.${tensor.nameOnParent}` : "")
+  );
+}
+
+let stackCounter = 0;
+
+export function track<Output>(
+  module: Module<unknown, Output>,
+  ...args: Parameters<typeof module.forward>
+): [Output, TrackedTensor[]] {
+  const stackId = stackCounter++;
+  const tensors: TrackedTensor[] = [];
+  trackStacks[stackId] = {
+    stack: tensors,
+    alreadyTracked: new Set(),
+  };
+  try {
+    const result = module.forward(...args);
+    return [result, tensors];
+  } finally {
+    delete trackStacks[stackId];
+  }
+}
+
+export async function trackOptimizerStep(optimizer: Optimizer) {
+  const stackId = stackCounter++;
+  const tensors: TrackedTensor[] = [];
+  trackStacks[stackId] = {
+    stack: tensors,
+    alreadyTracked: new Set(),
+  };
+  try {
+    await optimizer.step();
+  } finally {
+    delete trackStacks[stackId];
+  }
+  return tensors;
+}

--- a/packages/web/src/optim/adamw.ts
+++ b/packages/web/src/optim/adamw.ts
@@ -1,0 +1,224 @@
+import { zerosLike } from "@/globals";
+import { tensorName, withScope } from "@/nn/tracking";
+import { Optimizer } from "@/optim/optimizer";
+import { OptimizerParamState, ParamGroup } from "@/optim/optimizer";
+import { Parameter } from "@/parameter";
+import { Tensor } from "@/tensor";
+import { Device } from "@/wasm";
+
+export interface AdamWParamState extends OptimizerParamState {
+  step: number;
+  expAvg: Tensor | null;
+  expAvgSq: Tensor | null;
+  maxExpAvgSq?: Tensor | null;
+}
+
+export interface AdamWParamGroup extends ParamGroup {
+  lr: number;
+  betas: [number, number];
+  eps: number;
+  weightDecay: number;
+  amsgrad: boolean;
+}
+
+export interface AdamWConfig {
+  lr: number;
+  betas: [number, number];
+  eps: number;
+  weightDecay: number;
+  amsgrad: boolean;
+}
+
+/**
+ * Implementation of the AdamW optimizer (based on original PyTorch
+ * implementation)
+ *
+ * The original Adam algorithm was proposed in "Adam: A Method for Stochastic
+ * Optimization".
+ * The AdamW variant was proposed in "Decoupled Weight Decay Regularization".
+ */
+export class AdamW extends Optimizer<AdamWParamState> {
+  /**
+   * Creates a new AdamW optimizer
+   *
+   * @param params - Parameters or parameter groups to optimize
+   * @param device - The device to perform computations on
+   * @param config - Configuration options for the optimizer:
+   *  - `lr` (number): Learning rate (default: 1e-3)
+   *  - `betas` ([number, number]): Coefficients for computing running averages 
+   *     of gradient and its square (default: [0.9, 0.999])
+   *  - `eps` (number): Term added to denominator for numerical stability
+   *    (default: 1e-8)
+   *  - `weightDecay` (number): Weight decay coefficient (default: 1e-2)
+   *  - `amsgrad` (boolean): Whether to use the AMSGrad variant (default: false)
+   */
+  constructor(
+    params: Parameter[] | ParamGroup[],
+    device: Device,
+    config?: Partial<AdamWConfig>,
+  ) {
+    const {
+      lr = 1e-3,
+      betas = [0.9, 0.999],
+      eps = 1e-8,
+      weightDecay = 1e-2,
+      amsgrad = false,
+    } = config ?? {};
+
+    // Validate parameters
+    if (!(lr >= 0)) {
+      throw new Error(`Invalid learning rate: ${lr}`);
+    }
+    if (!(eps >= 0)) {
+      throw new Error(`Invalid epsilon value: ${eps}`);
+    }
+    if (!(betas[0] >= 0 && betas[0] < 1)) {
+      throw new Error(`Invalid beta parameter at index 0: ${betas[0]}`);
+    }
+    if (!(betas[1] >= 0 && betas[1] < 1)) {
+      throw new Error(`Invalid beta parameter at index 1: ${betas[1]}`);
+    }
+    if (!(weightDecay >= 0)) {
+      throw new Error(`Invalid weight_decay value: ${weightDecay}`);
+    }
+
+    // Initialize with default options
+    const defaults = {
+      lr,
+      betas,
+      eps,
+      weightDecay,
+      amsgrad,
+    };
+
+    super(params, device, defaults);
+  }
+
+  /**
+   * Performs a single optimization step
+   *
+   * @param closure - Closure that reevaluates the model and returns the loss
+   * @returns The loss value if closure is provided
+   */
+  async step(closure?: () => number): Promise<number | undefined> {
+    let loss: number | undefined;
+
+    // Call closure if provided
+    if (closure) {
+      loss = closure();
+    }
+
+    // Perform optimization for each parameter group
+    let paramGroupIndex = 0;
+    for (const group of this.paramGroups) {
+      withScope(
+        [
+          {
+            type: "optimizer-param-group",
+            optimizer: this,
+            paramGroup: group,
+            name: paramGroupIndex.toString(),
+          },
+        ],
+        () => {
+          paramGroupIndex++;
+
+          const {
+            lr = this.defaults.lr as number,
+            betas = this.defaults.betas as [number, number],
+            eps = this.defaults.eps as number,
+            weightDecay = this.defaults.weightDecay as number,
+            amsgrad = this.defaults.amsgrad as number,
+          } = group as AdamWParamGroup;
+
+          const [beta1, beta2] = betas as [number, number];
+
+          for (const param of group.params) {
+            if (!param.grad()) {
+              continue;
+            }
+
+            withScope(
+              [
+                {
+                  type: "optimizer-param-update",
+                  optimizer: this,
+                  parameter: param,
+                  name: tensorName(param),
+                },
+              ],
+              () => {
+                const grad = param.grad() as Tensor;
+
+                // Apply weight decay
+                if (weightDecay !== 0) {
+                  param.mul_(1 - lr * weightDecay);
+                }
+
+                // Get parameter state
+                let state = this.state.get(param);
+                if (!state) {
+                  state = {
+                    step: 0,
+                    expAvg: zerosLike(param),
+                    expAvgSq: zerosLike(param),
+                  };
+
+                  if (amsgrad) {
+                    state.maxExpAvgSq = zerosLike(param);
+                  }
+
+                  this.state.set(param, state);
+                }
+
+                const expAvg = state.expAvg as Tensor;
+                const expAvgSq = state.expAvgSq as Tensor;
+                const maxExpAvgSq = amsgrad
+                  ? (state.maxExpAvgSq as Tensor)
+                  : null;
+
+                // Increment step counter
+                state.step++;
+
+                // Decay the first and second moment running average coefficient
+                expAvg.mul_(beta1).add_(grad.mul(1 - beta1));
+                expAvgSq.mul_(beta2).addcmul_(grad, grad, 1 - beta2);
+
+                // Compute bias correction terms
+                const biasCorrection1 = 1 - Math.pow(beta1, state.step);
+                const biasCorrection2 = 1 - Math.pow(beta2, state.step);
+
+                // Use the max avg squared if using amsgrad
+                let denom;
+                if (amsgrad) {
+                  // Update max exponential moving average of squared gradient
+                  maxExpAvgSq!.maximum_(expAvgSq);
+                  // Use the max for normalization
+                  denom = maxExpAvgSq!
+                    .sqrt()
+                    .div(Math.sqrt(biasCorrection2))
+                    .add(eps);
+                } else {
+                  denom = expAvgSq
+                    .sqrt()
+                    .div(Math.sqrt(biasCorrection2))
+                    .add(eps);
+                }
+
+                // Compute step size
+                const stepSize = lr / biasCorrection1;
+
+                // Update parameters
+                param.addcdiv_(expAvg, denom, -stepSize);
+              },
+            );
+          }
+        },
+      );
+    }
+
+    await this.device.markStep();
+
+    return loss;
+  }
+}

--- a/packages/web/src/optim/index.ts
+++ b/packages/web/src/optim/index.ts
@@ -1,0 +1,11 @@
+export { AdamW, AdamWConfig } from "./adamw";
+export {
+  Optimizer,
+  type OptimizerParamState,
+  type OptimizerPostHook,
+  type OptimizerPreHook,
+  type ParamGroup,
+  type ParamGroupConfig,
+  type StateDict,
+} from "./optimizer";
+export { SGD, SGDConfig } from "./sgd";

--- a/packages/web/src/optim/optimizer.ts
+++ b/packages/web/src/optim/optimizer.ts
@@ -1,0 +1,408 @@
+import { ScopeItem, withScope } from "@/nn/tracking";
+import { Parameter } from "@/parameter";
+import { Tensor } from "@/tensor";
+import { RemovableHandle } from "@/utils";
+import { Device } from "@/wasm";
+
+/**
+ * Base configuration for parameter groups
+ */
+export interface ParamGroupConfig {
+  params: number[];
+  [key: string]: unknown;
+}
+
+/**
+ * Runtime parameter group with actual Parameter objects
+ */
+export interface ParamGroup {
+  params: Parameter[];
+  lr?: number;
+  weightDecay?: number;
+  [key: string]: unknown;
+}
+
+/**
+ * Type alias for optimizer pre-hook function
+ * Returns modified args and kwargs if needed, or undefined if no changes
+ */
+export type OptimizerPreHook = (
+  optimizer: Optimizer,
+  args: unknown[],
+  kwargs: Record<string, unknown>,
+) => [unknown[], Record<string, unknown>] | undefined;
+
+/**
+ * Type alias for optimizer post-hook function
+ */
+export type OptimizerPostHook = (
+  optimizer: Optimizer,
+  args: unknown[],
+  kwargs: Record<string, unknown>,
+) => void;
+
+/**
+ * Base type for optimizer parameter state
+ */
+export interface OptimizerParamState {
+  step?: number;
+}
+
+/**
+ * Type for optimizer state dictionary serialization
+ */
+export interface StateDict {
+  state: Record<number, OptimizerParamState>;
+  paramGroups: ParamGroupConfig[];
+}
+
+/**
+ * Base class for all optimizers
+ *
+ * This class defines the interface and common functionality for all optimizers.
+ * Subclasses should implement the `step` method which performs the actual
+ * parameter updates.
+ */
+export class Optimizer<
+  TState extends OptimizerParamState = OptimizerParamState,
+> {
+  defaults: Record<string, unknown>;
+  device: Device;
+  state: Map<Parameter, TState>;
+  paramGroups: ParamGroup[];
+  scope: ScopeItem[] | undefined;
+  private _optimizerStepPreHooks: Map<number, OptimizerPreHook>;
+  private _optimizerStepPostHooks: Map<number, OptimizerPostHook>;
+
+  /**
+   * Creates a new optimizer
+   *
+   * @param params - Iterable of parameters or parameter groups
+   * @param defaults - Default optimization options
+   */
+  constructor(
+    params: Parameter[] | ParamGroup[],
+    device: Device,
+    defaults: Record<string, unknown>,
+  ) {
+    this.defaults = defaults;
+    this.device = device;
+    this.state = new Map();
+    this.paramGroups = [];
+    this._optimizerStepPreHooks = new Map();
+    this._optimizerStepPostHooks = new Map();
+
+    if (params instanceof Parameter) {
+      throw new TypeError(
+        "params argument given to the optimizer should be an iterable of " +
+          "Parameters or parameter groups",
+      );
+    }
+
+    const paramGroups = Array.isArray(params) ? [...params] : params;
+    if (paramGroups.length === 0) {
+      throw new Error("Optimizer got an empty parameter list");
+    }
+
+    if (!("params" in paramGroups[0])) {
+      // If the first element doesn't have a params field, assume all elements are Parameters
+      // and convert to a single parameter group
+      this.addParamGroup({ params: paramGroups as Parameter[] });
+    } else {
+      // Otherwise, we have parameter groups
+      for (const group of paramGroups as ParamGroup[]) {
+        this.addParamGroup(group);
+      }
+    }
+
+    // Return a proxy to intercept method calls like 'step'
+    return new Proxy(this, {
+      get: (
+        target: Optimizer<TState>,
+        prop: string | symbol,
+        receiver: unknown,
+      ): unknown => {
+        // Intercept the 'step' method
+        if (prop === "step" && typeof target.step === "function") {
+          const originalStep = Reflect.get(target, prop, receiver) as (
+            ...args: unknown[]
+          ) => Promise<number | undefined>;
+
+          // Return a wrapped async function
+          return async function (
+            ...args: unknown[]
+          ): Promise<number | undefined> {
+            return withScope(
+              [
+                {
+                  type: "optimizer",
+                  optimizer: target,
+                  name: undefined,
+                },
+                ...(target.scope ?? []),
+              ],
+              () => {
+                return Reflect.apply(originalStep, receiver, args);
+              },
+              { replace: true },
+            );
+          };
+        }
+
+        // Default behavior for other properties and methods
+        return Reflect.get(target, prop, receiver);
+      },
+    }) as Optimizer<TState>;
+  }
+
+  /**
+   * Register an optimizer step pre-hook
+   * The hook will be called before each optimizer step
+   *
+   * @param hook - Function to call before step
+   * @returns A handle that can be used to remove the hook
+   */
+  registerStepPreHook(hook: OptimizerPreHook): RemovableHandle {
+    const handle = new RemovableHandle(this._optimizerStepPreHooks);
+    this._optimizerStepPreHooks.set(handle.id, hook);
+    return handle;
+  }
+
+  /**
+   * Register an optimizer step post-hook
+   * The hook will be called after each optimizer step
+   *
+   * @param hook - Function to call after step
+   * @returns A handle that can be used to remove the hook
+   */
+  registerStepPostHook(hook: OptimizerPostHook): RemovableHandle {
+    const handle = new RemovableHandle(this._optimizerStepPostHooks);
+    this._optimizerStepPostHooks.set(handle.id, hook);
+    return handle;
+  }
+
+  /**
+   * Adds a parameter group to the optimizer
+   *
+   * @param paramGroup - Parameter group to add
+   */
+  addParamGroup(paramGroup: ParamGroup): void {
+    if (typeof paramGroup !== "object") {
+      throw new TypeError("Parameter group must be an object");
+    }
+
+    let params = paramGroup.params;
+    if (!Array.isArray(params)) {
+      params = [params as Parameter];
+    }
+
+    // Create a new parameter group with defaults
+    const group: ParamGroup = { ...this.defaults, ...paramGroup, params: [] };
+
+    // Check parameters
+    for (const param of params) {
+      if (!(param instanceof Parameter)) {
+        throw new TypeError(
+          "Optimizer can only optimize Parameters, " +
+            // @ts-expect-error - we're checking that param is a Parameter
+            `but one of the params is ${param?.constructor?.name}`,
+        );
+      }
+
+      // Check if parameter is already in another group
+      for (const existingGroup of this.paramGroups) {
+        if (existingGroup.params.includes(param)) {
+          throw new Error(
+            "Some parameters appear in more than one parameter group",
+          );
+        }
+      }
+
+      (group.params as Parameter[]).push(param);
+    }
+
+    this.paramGroups.push(group);
+  }
+
+  /**
+   * Returns the state of the optimizer as a dict
+   *
+   * @returns State dictionary
+   */
+  stateDict(): StateDict {
+    // Map parameters to indices
+    const paramMappings = new Map<Parameter, number>();
+    let startIndex = 0;
+
+    // Pack groups with parameter indices
+    const packedGroups = this.paramGroups.map((group) => {
+      const packed: Record<string, unknown> = { ...group };
+      delete packed.params;
+
+      // Map parameters to indices
+      for (const param of group.params) {
+        if (!paramMappings.has(param)) {
+          paramMappings.set(param, startIndex++);
+        }
+      }
+
+      // Store param indices
+      packed.params = group.params.map((p) => paramMappings.get(p));
+      return packed;
+    });
+
+    // Remap state to use indices as keys
+    const packedState: Record<number, unknown> = {};
+    this.state.forEach((value, key) => {
+      const paramId = paramMappings.get(key) as number;
+      packedState[paramId] = { ...value };
+    });
+
+    return {
+      state: packedState as Record<number, TState>,
+      paramGroups: packedGroups as ParamGroupConfig[],
+    };
+  }
+
+  /**
+   * Loads optimizer state
+   *
+   * @param stateDict - State dictionary to load
+   */
+  loadStateDict(stateDict: StateDict): void {
+    // Validate the state dict
+    const groups = this.paramGroups;
+    const savedGroups = stateDict.paramGroups;
+
+    if (groups.length !== savedGroups.length) {
+      throw new Error(
+        "Loaded state dict has a different number of parameter groups",
+      );
+    }
+
+    const paramLens = groups.map((g) => g.params.length);
+    const savedLens = savedGroups.map((g) => g.params.length);
+
+    if (paramLens.some((len, i) => len !== savedLens[i])) {
+      throw new Error(
+        "Loaded state dict contains a parameter group " +
+          "that doesn't match the size of optimizer's group",
+      );
+    }
+
+    // Create a map from saved parameter indices to current parameters
+    const idMap = new Map<number, Parameter>();
+    savedGroups.forEach((savedGroup, i) => {
+      const group = groups[i];
+      (savedGroup.params as number[]).forEach((paramId, j) => {
+        idMap.set(paramId, group.params[j]);
+      });
+    });
+
+    // Update the state
+    const newState = new Map<Parameter, TState>();
+    for (const [paramId, savedState] of Object.entries(stateDict.state)) {
+      const param = idMap.get(Number(paramId));
+      if (param) {
+        // Copy state to parameter
+        newState.set(param, this._processValue(param, savedState) as TState);
+      }
+    }
+    this.state = newState;
+
+    // Update parameter groups
+    groups.forEach((group, i) => {
+      const savedGroup = savedGroups[i];
+      for (const key of Object.keys(savedGroup)) {
+        if (key !== "params") {
+          group[key] = savedGroup[key];
+        }
+      }
+    });
+  }
+
+  /**
+   * Helper function to process values from state dict
+   */
+  protected _processValue(param: Parameter, value: unknown): unknown {
+    if (value instanceof Tensor) {
+      // Move tensor to same device and cast to param dtype if floating point
+      if (param.dtype().isFloatingPoint()) {
+        return value.cast(param.dtype());
+      }
+      return value;
+    } else if (Array.isArray(value)) {
+      return value.map((v) => this._processValue(param, v));
+    } else if (typeof value === "object" && value !== null) {
+      const result: Record<string, unknown> = {};
+      for (const [k, v] of Object.entries(value)) {
+        result[k] = this._processValue(param, v);
+      }
+      return result;
+    }
+    return value;
+  }
+
+  /**
+   * Zero out the gradients of all parameters
+   *
+   * @param setToNone - If true, set gradients to null instead of zero
+   */
+  zeroGrad(setToNone: boolean = true): void {
+    for (const group of this.paramGroups) {
+      for (const param of group.params) {
+        const grad = param.grad();
+        if (grad) {
+          if (setToNone) {
+            // TODO: Need to implement proper "set grad to null" logic
+            grad.mul(0); // For now, just zero it out
+          } else {
+            grad.mul(0);
+          }
+        }
+      }
+    }
+  }
+
+  /**
+   * Performs a single optimization step
+   *
+   * @param closure - Closure that reevaluates the model and returns the loss
+   * @returns The loss value
+   */
+  async step(_closure?: () => number): Promise<number | undefined> {
+    throw new Error("Subclasses must implement the step method");
+  }
+
+  /**
+   * Performs a single optimization step with hook handling
+   *
+   * @param originalStep - The actual step implementation
+   * @param args - Arguments to pass to step
+   * @param kwargs - Keyword arguments to pass to step
+   * @returns The result of the step function
+   */
+  protected _stateWithHooks(
+    originalStep: (...args: unknown[]) => unknown,
+    args: unknown[] = [],
+    kwargs: Record<string, unknown> = {},
+  ): unknown {
+    // Call pre-hooks
+    for (const preHook of this._optimizerStepPreHooks.values()) {
+      const result = preHook(this, args, kwargs);
+      if (result) {
+        [args, kwargs] = result;
+      }
+    }
+
+    // Call the actual step function
+    const result = originalStep.apply(this, args);
+
+    // Call post-hooks
+    for (const postHook of this._optimizerStepPostHooks.values()) {
+      postHook(this, args, kwargs);
+    }
+
+    return result;
+  }
+}

--- a/packages/web/src/optim/sgd.ts
+++ b/packages/web/src/optim/sgd.ts
@@ -1,0 +1,185 @@
+import { zerosLike } from "@/globals";
+import { tensorName, withScope } from "@/nn/tracking";
+import { Optimizer } from "@/optim/optimizer";
+import { OptimizerParamState, ParamGroup } from "@/optim/optimizer";
+import { Parameter } from "@/parameter";
+import { Tensor } from "@/tensor";
+import { Device } from "@/wasm";
+
+export interface SGDParamState extends OptimizerParamState {
+  momentumBuffer?: Tensor | null;
+}
+
+export interface SGDParamGroup extends ParamGroup {
+  lr: number;
+  momentum: number;
+  dampening: number;
+  weightDecay: number;
+  nesterov: boolean;
+}
+
+export interface SGDConfig {
+  lr: number;
+  momentum: number;
+  dampening: number;
+  weightDecay: number;
+  nesterov: boolean;
+}
+
+/**
+ * Implementation of the SGD optimizer (based on original PyTorch
+ * implementation)
+ *
+ * Nesterov momentum is based on the paper "On the importance of initialization
+ * and momentum in deep learning".
+ */
+export class SGD extends Optimizer<SGDParamState> {
+  /**
+   * Creates a new SGD optimizer
+   *
+   * @param params - Parameters or parameter groups to optimize
+   * @param device - The device to perform computations on
+   * @param config - Configuration options for the optimizer:
+   *  - `lr` (number): Learning rate (REQUIRED)
+   *  - `momentum` (number): Momentum factor (default: 0)
+   *  - `dampening` (number): Dampening for momentum (default: 0)
+   *  - `weightDecay` (number): Weight decay (L2 penalty) (default: 0)
+   *  - `nesterov` (boolean): Enables Nesterov momentum (default: false)
+   */
+  constructor(
+    params: Parameter[] | ParamGroup[],
+    device: Device,
+    config: Partial<SGDConfig> & Pick<SGDConfig, "lr">,
+  ) {
+    const {
+      lr,
+      momentum = 0,
+      dampening = 0,
+      weightDecay = 0,
+      nesterov = false,
+    } = config;
+
+    // Validate parameters
+    if (!(lr >= 0)) {
+      throw new Error(`Invalid learning rate: ${lr}`);
+    }
+    if (!(momentum >= 0)) {
+      throw new Error(`Invalid momentum value: ${momentum}`);
+    }
+    if (!(weightDecay >= 0)) {
+      throw new Error(`Invalid weight_decay value: ${weightDecay}`);
+    }
+    if (nesterov && (momentum <= 0 || dampening !== 0)) {
+      throw new Error(
+        "Nesterov momentum requires a momentum and zero dampening",
+      );
+    }
+
+    // Initialize with default options
+    const defaults = {
+      lr,
+      momentum,
+      dampening,
+      weightDecay,
+      nesterov,
+    };
+
+    super(params, device, defaults);
+  }
+
+  /**
+   * Performs a single optimization step
+   *
+   * @param closure - Closure that reevaluates the model and returns the loss
+   * @returns The loss value if closure is provided
+   */
+  async step(closure?: () => number): Promise<number | undefined> {
+    let loss: number | undefined;
+
+    // Call closure if provided
+    if (closure) {
+      loss = closure();
+    }
+
+    // Perform optimization for each parameter group
+    let paramGroupIndex = 0;
+    for (const group of this.paramGroups) {
+      const {
+        lr = this.defaults.lr as number,
+        momentum = this.defaults.momentum as number,
+        dampening = this.defaults.dampening as number,
+        weightDecay = this.defaults.weightDecay as number,
+        nesterov = this.defaults.nesterov as boolean,
+      } = group as SGDParamGroup;
+
+      withScope(
+        [
+          {
+            type: "optimizer-param-group",
+            optimizer: this,
+            paramGroup: group,
+            name: paramGroupIndex.toString(),
+          },
+        ],
+        () => {
+          paramGroupIndex++;
+
+          for (const param of group.params) {
+            if (!param.grad()) {
+              continue;
+            }
+
+            withScope(
+              [
+                {
+                  type: "optimizer-param-update",
+                  optimizer: this,
+                  parameter: param,
+                  name: tensorName(param),
+                },
+              ],
+              () => {
+                let grad = param.grad() as Tensor;
+
+                // Apply weight decay
+                if (weightDecay !== 0) {
+                  grad = grad.add(param.mul(weightDecay));
+                }
+
+                // Apply momentum
+                if (momentum !== 0) {
+                  let state = this.state.get(param);
+                  if (!state) {
+                    state = {};
+                    this.state.set(param, state);
+                  }
+
+                  let buf = state.momentumBuffer;
+                  if (!buf) {
+                    buf = zerosLike(grad);
+                    state.momentumBuffer = buf;
+                  } else {
+                    buf.mul_(momentum).add_(grad.mul(1 - dampening));
+                  }
+
+                  if (nesterov) {
+                    grad = grad.add(buf!.mul(momentum));
+                  } else {
+                    grad = buf!;
+                  }
+                }
+
+                // Update parameters
+                param.add_(grad.mul(-lr));
+              },
+            );
+          }
+        },
+      );
+    }
+
+    await this.device.markStep();
+
+    return loss;
+  }
+}

--- a/packages/web/src/parameter.ts
+++ b/packages/web/src/parameter.ts
@@ -1,0 +1,7 @@
+import { Tensor } from "@/tensor";
+
+export class Parameter extends Tensor {
+  constructor(tensor: Tensor) {
+    super(Tensor._unwrap(tensor).requiresGrad_(true));
+  }
+}

--- a/packages/web/src/serialization.ts
+++ b/packages/web/src/serialization.ts
@@ -1,0 +1,25 @@
+import { Buffer } from "@/nn/module";
+import { Parameter } from "@/parameter";
+import { Tensor } from "@/tensor";
+import { save_wasm } from "@/wasm";
+
+export function save(stateDict: Record<string, Parameter | Buffer>) {
+  return save_wasm(
+    Object.fromEntries(
+      Object.entries(stateDict).map(([name, paramOrBuffer]) => {
+        if (paramOrBuffer instanceof Buffer) {
+          return [name, Tensor._unwrap(paramOrBuffer.data)];
+        }
+        if (paramOrBuffer instanceof Parameter) {
+          return [name, Tensor._unwrap(paramOrBuffer)];
+        }
+        throw new TypeError(
+          `Cannot save '${
+            (paramOrBuffer as unknown)?.constructor?.name ||
+            typeof paramOrBuffer
+          }' as parameter '${name}'`,
+        );
+      }),
+    ),
+  );
+}

--- a/packages/web/src/tensor.ts
+++ b/packages/web/src/tensor.ts
@@ -1,0 +1,530 @@
+import { BinaryOpInput, DimsType, ShapeType } from "@/types";
+import { DType, Tensor_wasm } from "@/wasm";
+
+import {
+  ScopeItem,
+  tensorScopeStack,
+  trackTensor,
+  trackTensors,
+} from "./nn/tracking";
+
+export type OpDescription = {
+  name: string;
+  // TODO(vinhowe): Fix this to be like the actual type
+  fields: Record<string, unknown>;
+};
+
+export class Tensor {
+  scope: ScopeItem[] | undefined;
+  nameOnParent: string | undefined;
+  constructor(private readonly innerTensor: Tensor_wasm) {
+    this.scope = [...tensorScopeStack];
+  }
+
+  // Helper method to access inner tensor for internal use
+  static _unwrap(tensor: Tensor): Tensor_wasm {
+    return tensor?.innerTensor?._clone();
+  }
+
+  // Creates a new Tensor from a Tensor_wasm
+  static _wrap(tensor: Tensor_wasm): Tensor {
+    // TODO: This might be more cloning than necessary
+    return new Tensor(tensor._clone());
+  }
+
+  // Create a scalar tensor (empty shape) with the given value
+  static scalar(value: number, dtype?: DType): Tensor {
+    return Tensor._wrap(
+      Tensor_wasm.full([], value, dtype || null, null, false),
+    );
+  }
+
+  private wrappedOp(op: (a: Tensor_wasm) => Tensor_wasm): Tensor {
+    trackTensor(this, { dependency: true });
+    const result = Tensor._wrap(op(this._cloneInner()));
+    trackTensor(result);
+    return result;
+  }
+
+  // Define binary operations using a constructor
+  private makeBinaryOp(
+    name: keyof Tensor_wasm,
+  ): (other: BinaryOpInput) => Tensor {
+    return (other: BinaryOpInput): Tensor => {
+      const otherValue = other instanceof Tensor ? other._cloneInner() : other;
+      if (otherValue instanceof Tensor) {
+        trackTensor(otherValue, { dependency: true });
+      }
+      return this.wrappedOp((a) =>
+        (a[name] as (b: Tensor_wasm) => Tensor_wasm)(otherValue),
+      );
+    };
+  }
+
+  add = this.makeBinaryOp("add");
+  add_ = this.makeBinaryOp("add_");
+  sub = this.makeBinaryOp("sub");
+  sub_ = this.makeBinaryOp("sub_");
+  mul = this.makeBinaryOp("mul");
+  mul_ = this.makeBinaryOp("mul_");
+  div = this.makeBinaryOp("div");
+  div_ = this.makeBinaryOp("div_");
+  minimum = this.makeBinaryOp("minimum");
+  minimum_ = this.makeBinaryOp("minimum_");
+  maximum = this.makeBinaryOp("maximum");
+  maximum_ = this.makeBinaryOp("maximum_");
+
+  private makeTernaryOp(
+    name: keyof Tensor_wasm,
+  ): (tensor1: Tensor, tensor2: Tensor, value: number) => Tensor {
+    return (tensor1: Tensor, tensor2: Tensor, value: number): Tensor => {
+      trackTensors([tensor1, tensor2], { dependency: true });
+      return this.wrappedOp((a) =>
+        (a[name] as (b: Tensor_wasm, c: Tensor_wasm, d: number) => Tensor_wasm)(
+          tensor1._cloneInner(),
+          tensor2._cloneInner(),
+          value,
+        ),
+      );
+    };
+  }
+
+  addcdiv = this.makeTernaryOp("addcdiv");
+  addcdiv_ = this.makeTernaryOp("addcdiv_");
+  addcmul = this.makeTernaryOp("addcmul");
+  addcmul_ = this.makeTernaryOp("addcmul_");
+
+  private makeCmpOp(name: keyof Tensor_wasm): (other: Tensor) => Tensor {
+    return (other: Tensor): Tensor => {
+      trackTensor(other, { dependency: true });
+      return this.wrappedOp((a) =>
+        (a[name] as (b: Tensor_wasm) => Tensor_wasm)(other._cloneInner()),
+      );
+    };
+  }
+
+  eq = this.makeCmpOp("eq");
+  eq_ = this.makeCmpOp("eq_");
+  ne = this.makeCmpOp("ne");
+  ne_ = this.makeCmpOp("ne_");
+  gt = this.makeCmpOp("gt");
+  gt_ = this.makeCmpOp("gt_");
+  ge = this.makeCmpOp("ge");
+  ge_ = this.makeCmpOp("ge_");
+  lt = this.makeCmpOp("lt");
+  lt_ = this.makeCmpOp("lt_");
+  le = this.makeCmpOp("le");
+  le_ = this.makeCmpOp("le_");
+
+  private makeUnaryOp(name: keyof Tensor_wasm): () => Tensor {
+    return (): Tensor =>
+      this.wrappedOp((a) => (a[name] as () => Tensor_wasm)());
+  }
+
+  gelu = this.makeUnaryOp("gelu");
+  gelu_ = this.makeUnaryOp("gelu_");
+  tanh = this.makeUnaryOp("tanh");
+  tanh_ = this.makeUnaryOp("tanh_");
+  exp = this.makeUnaryOp("exp");
+  exp_ = this.makeUnaryOp("exp_");
+  log = this.makeUnaryOp("log");
+  log_ = this.makeUnaryOp("log_");
+  sin = this.makeUnaryOp("sin");
+  sin_ = this.makeUnaryOp("sin_");
+  cos = this.makeUnaryOp("cos");
+  cos_ = this.makeUnaryOp("cos_");
+  abs = this.makeUnaryOp("abs");
+  abs_ = this.makeUnaryOp("abs_");
+  sqrt = this.makeUnaryOp("sqrt");
+  sqrt_ = this.makeUnaryOp("sqrt_");
+  relu = this.makeUnaryOp("relu");
+  relu_ = this.makeUnaryOp("relu_");
+  relu2 = this.makeUnaryOp("relu2");
+  relu2_ = this.makeUnaryOp("relu2_");
+  floor = this.makeUnaryOp("floor");
+  floor_ = this.makeUnaryOp("floor_");
+  ceil = this.makeUnaryOp("ceil");
+  ceil_ = this.makeUnaryOp("ceil_");
+  neg = this.makeUnaryOp("neg");
+  neg_ = this.makeUnaryOp("neg_");
+  sigmoid = this.makeUnaryOp("sigmoid");
+  sigmoid_ = this.makeUnaryOp("sigmoid_");
+  swiglu = this.makeUnaryOp("swiglu");
+  swiglu_ = this.makeUnaryOp("swiglu_");
+  silu = this.makeUnaryOp("silu");
+  silu_ = this.makeUnaryOp("silu_");
+  square = this.makeUnaryOp("square");
+  square_ = this.makeUnaryOp("square_");
+  recip = this.makeUnaryOp("recip");
+  recip_ = this.makeUnaryOp("recip_");
+
+  float = this.makeUnaryOp("float");
+  half = this.makeUnaryOp("half");
+
+  cast(dstDtype?: DType): Tensor {
+    return this.wrappedOp((a) => a.cast(dstDtype?._clone()));
+  }
+
+  groupNorm(
+    numGroups: number,
+    weight: Tensor,
+    bias?: Tensor,
+    eps: number = 1e-5,
+  ): Tensor {
+    trackTensor(weight, { dependency: true });
+    if (bias) {
+      trackTensor(bias, { dependency: true });
+    }
+    return this.wrappedOp((a) =>
+      a.groupNorm(
+        numGroups,
+        weight?._cloneInner(),
+        bias ? bias._cloneInner() : null,
+        eps,
+      ),
+    );
+  }
+
+  layerNorm(weight: Tensor, bias?: Tensor, eps: number = 1e-5): Tensor {
+    trackTensor(weight, { dependency: true });
+    if (bias) {
+      trackTensor(bias, { dependency: true });
+    }
+    return this.wrappedOp((a) =>
+      a.layerNorm(weight?._cloneInner(), bias ? bias._cloneInner() : null, eps),
+    );
+  }
+
+  rmsNorm(weight: Tensor, eps: number = 1e-5): Tensor {
+    trackTensor(weight, { dependency: true });
+    return this.wrappedOp((a) => a.rmsNorm(weight?._cloneInner(), eps));
+  }
+
+  conv1d(
+    weight: Tensor,
+    bias?: Tensor,
+    stride: number = 1,
+    padding: number = 0,
+  ): Tensor {
+    trackTensor(weight, { dependency: true });
+    if (bias) {
+      trackTensor(bias, { dependency: true });
+    }
+    return this.wrappedOp((a) =>
+      a.conv1d(
+        weight?._cloneInner(),
+        bias ? bias._cloneInner() : null,
+        stride,
+        padding,
+      ),
+    );
+  }
+
+  softmax(dim: number): Tensor {
+    return this.wrappedOp((a) => a.softmax(dim));
+  }
+
+  rope(dim: number, base: number, offset: number): Tensor {
+    return this.wrappedOp((a) => a.rope(dim, base, offset));
+  }
+
+  alibi(maxBias: number): Tensor {
+    return this.wrappedOp((a) => a.alibi(maxBias));
+  }
+
+  matmul(
+    rhs: Tensor,
+    transLhs: boolean = false,
+    transRhs: boolean = false,
+  ): Tensor {
+    trackTensor(rhs, { dependency: true });
+    return this.wrappedOp((a) =>
+      a.matmul(rhs._cloneInner(), transLhs, transRhs),
+    );
+  }
+
+  gemm(
+    rhs: Tensor,
+    bias?: Tensor,
+    transLhs: boolean = false,
+    transRhs: boolean = false,
+    transOut: boolean = false,
+  ): Tensor {
+    trackTensor(rhs, { dependency: true });
+    if (bias) {
+      trackTensor(bias, { dependency: true });
+    }
+    return this.wrappedOp((a) =>
+      a.gemm(
+        rhs._cloneInner(),
+        bias ? bias._cloneInner() : null,
+        transLhs,
+        transRhs,
+        transOut,
+      ),
+    );
+  }
+
+  affine(mul: number, add: number): Tensor {
+    return this.wrappedOp((a) => a.affine(mul, add));
+  }
+
+  pow(e: number): Tensor {
+    return this.wrappedOp((a) => a.pow(e));
+  }
+
+  pow_(e: number): Tensor {
+    return this.wrappedOp((a) => a.pow_(e));
+  }
+
+  sum(dim?: DimsType, keepdim?: boolean): Tensor {
+    return this.wrappedOp((a) => a.sum(dim as Int32Array, keepdim ?? false));
+  }
+
+  mean(dim?: DimsType, keepdim?: boolean): Tensor {
+    return this.wrappedOp((a) => a.mean(dim as Int32Array, keepdim ?? false));
+  }
+
+  var(dim?: DimsType, keepdim?: boolean): Tensor {
+    return this.wrappedOp((a) => a.var(dim, keepdim ?? false));
+  }
+
+  max(dim: number, keepdim?: boolean): Tensor {
+    return this.wrappedOp((a) => a.max(dim, keepdim ?? false));
+  }
+
+  min(dim: number, keepdim?: boolean): Tensor {
+    return this.wrappedOp((a) => a.min(dim, keepdim ?? false));
+  }
+
+  argmax(dim: number, keepdim?: boolean): Tensor {
+    return this.wrappedOp((a) => a.argmax(dim, keepdim ?? false));
+  }
+
+  argmin(dim: number, keepdim?: boolean): Tensor {
+    return this.wrappedOp((a) => a.argmin(dim, keepdim ?? false));
+  }
+
+  norm(): Tensor {
+    return this.wrappedOp((a) => a.norm());
+  }
+
+  flatten(startDim?: number, endDim?: number): Tensor {
+    return this.wrappedOp((a) => a.flatten(startDim, endDim));
+  }
+
+  // TODO: Replace with more expressive indexer .i
+  slice(ranges: number[][]): Tensor {
+    return this.wrappedOp((a) => a.slice(ranges));
+  }
+
+  view(...shape: number[] | [number[]]): Tensor {
+    if (shape.length === 1 && Array.isArray(shape[0])) {
+      return this.wrappedOp((a) => a.view(shape[0] as number[]));
+    } else {
+      return this.wrappedOp((a) => a.view(shape as number[]));
+    }
+  }
+
+  unsqueeze(dim: number): Tensor {
+    return this.wrappedOp((a) => a.unsqueeze(dim));
+  }
+
+  squeeze(dims?: DimsType): Tensor {
+    return this.wrappedOp((a) => a.squeeze(dims));
+  }
+
+  permute(dims: DimsType): Tensor {
+    return this.wrappedOp((a) => a.permute(dims));
+  }
+
+  cache(source: Tensor, dim: number, offset: number): Tensor {
+    trackTensor(source, { dependency: true });
+    return this.wrappedOp((a) => a.cache(source._cloneInner(), dim, offset));
+  }
+
+  broadcastLeft(leftShape: ShapeType): Tensor {
+    return this.wrappedOp((a) => a.broadcastLeft(leftShape));
+  }
+
+  broadcastTo(shape: ShapeType): Tensor {
+    return this.wrappedOp((a) => a.broadcastTo(shape));
+  }
+
+  indexSelect(indices: Tensor, dim: number): Tensor {
+    trackTensor(indices, { dependency: true });
+    return this.wrappedOp((a) => a.indexSelect(indices._cloneInner(), dim));
+  }
+
+  indexWrite(src: Tensor, writeStart: DimsType): Tensor {
+    trackTensor(src, { dependency: true });
+    return this.wrappedOp((a) => a.indexWrite(src._cloneInner(), writeStart));
+  }
+
+  where(condition: Tensor, onFalse: Tensor): Tensor {
+    trackTensor(condition, { dependency: true });
+    trackTensor(onFalse, { dependency: true });
+    return this.wrappedOp((a) =>
+      a.whereCond(condition._cloneInner(), onFalse._cloneInner()),
+    );
+  }
+
+  scatterAdd(indices: Tensor, source: Tensor, dim: number): Tensor {
+    trackTensor(indices, { dependency: true });
+    trackTensor(source, { dependency: true });
+    return this.wrappedOp((a) =>
+      a.scatterAdd(indices._cloneInner(), source._cloneInner(), dim),
+    );
+  }
+
+  indexAdd_(indices: Tensor, source: Tensor, dim: number): Tensor {
+    trackTensor(indices, { dependency: true });
+    trackTensor(source, { dependency: true });
+    return this.wrappedOp((a) =>
+      a.indexAdd_(indices._cloneInner(), source._cloneInner(), dim),
+    );
+  }
+
+  gather(indices: Tensor, dim: number): Tensor {
+    trackTensor(indices, { dependency: true });
+    return this.wrappedOp((a) => a.gather(indices._cloneInner(), dim));
+  }
+
+  triu(k?: number): Tensor {
+    return this.wrappedOp((a) => a.triu(k));
+  }
+
+  triu_(k?: number): Tensor {
+    return this.wrappedOp((a) => a.triu_(k));
+  }
+
+  tril(k?: number): Tensor {
+    return this.wrappedOp((a) => a.tril(k));
+  }
+
+  tril_(k?: number): Tensor {
+    return this.wrappedOp((a) => a.tril_(k));
+  }
+
+  bernoulli(): Tensor {
+    return this.wrappedOp((a) => a.bernoulli());
+  }
+
+  bernoulli_(): Tensor {
+    return this.wrappedOp((a) => a.bernoulli_());
+  }
+
+  // We skip onesLike and zerosLike because they're not defined as members in
+  // the Tensor class in PyTorch
+
+  // Tensor properties and operations
+  isContiguous(): boolean {
+    return this._cloneInner().isContiguous();
+  }
+
+  contiguous(): Tensor {
+    return this.wrappedOp((a) => a.contiguous());
+  }
+
+  detach(): Tensor {
+    return this.wrappedOp((a) => a.detach());
+  }
+
+  detach_(): Tensor {
+    return this.wrappedOp((a) => a.detach_());
+  }
+
+  requiresGrad_(requiresGrad: boolean = true): Tensor {
+    return this.wrappedOp((a) => a.requiresGrad_(requiresGrad));
+  }
+
+  async item(dtype?: DType): Promise<number> {
+    return this._cloneInner().item(dtype);
+  }
+
+  async toVec(dtype?: DType): Promise<Float32Array | Int32Array | Uint32Array> {
+    return this._cloneInner().toVec(dtype);
+  }
+
+  async to(device: string): Promise<Tensor> {
+    return Tensor._wrap(await this._cloneInner().to(device));
+  }
+
+  hasNaN(dtype?: DType): boolean {
+    return this._cloneInner().hasNaN(dtype);
+  }
+
+  // Getter methods for tensor properties
+  id(): number {
+    return this._cloneInner().id();
+  }
+
+  rank(): number {
+    return this._cloneInner().rank();
+  }
+
+  dtype(): DType {
+    return this._cloneInner().dtype();
+  }
+
+  size(): number[];
+  size(dim: number): number;
+  size(dim?: number): number | number[] {
+    return this._cloneInner().size(dim);
+  }
+
+  stride(): number[];
+  stride(dim: number): number;
+  stride(dim?: number): number | number[] {
+    return this._cloneInner().stride(dim);
+  }
+
+  get shape(): number[] {
+    return Array.from(this._cloneInner().shape());
+  }
+
+  get device(): string {
+    return this._cloneInner().device();
+  }
+
+  resolved(): boolean {
+    return this._cloneInner().resolved();
+  }
+
+  op(): OpDescription {
+    return this._cloneInner().op();
+  }
+
+  srcIds(): number[] {
+    return Array.from(this._cloneInner().srcIds());
+  }
+
+  storageId(): number | undefined {
+    return this._cloneInner().storageId();
+  }
+
+  isScalar(): boolean {
+    return this._cloneInner().isScalar();
+  }
+
+  requiresGrad(): boolean {
+    return this._cloneInner().requiresGrad();
+  }
+
+  debugTensor(): Tensor {
+    return Tensor._wrap(this._cloneInner().debugTensor());
+  }
+
+  grad(): Tensor | undefined {
+    const grad = this._cloneInner().grad();
+    return grad ? Tensor._wrap(grad) : undefined;
+  }
+
+  backward(): void {
+    this._cloneInner().backward();
+  }
+
+  private _cloneInner(): Tensor_wasm {
+    return this.innerTensor._clone();
+  }
+}

--- a/packages/web/src/types.d.ts
+++ b/packages/web/src/types.d.ts
@@ -1,0 +1,28 @@
+export type ShapeType = number[] | Uint32Array;
+export type ShapeWithHolesType = number[] | Int32Array;
+export type DimsType = number[] | Int32Array | number;
+export type NestedNumberList = number | NestedNumberList[];
+export type DeviceType = Device | "cpu" | "gpu" | "webgpu";
+export type BinaryOpInput = Tensor | number;
+
+export type DTypeInitConfig = {
+  dtype?: DType;
+};
+export type DeviceInitConfig = {
+  device?: DeviceType;
+};
+export type VarConfig = {
+  requiresGrad?: boolean;
+};
+export type OptionalShapeConfig = {
+  shape?: ShapeType;
+};
+export type FullInitConfig = DTypeInitConfig & DeviceInitConfig & VarConfig;
+
+export type RequiresGradConfig = VarConfig & { requiresGrad: true };
+export type TensorCreationFunction<Args extends unknown[]> = {
+  (...args: [...Args, RequiresGradConfig]): Parameter;
+  (...args: [...Args, FullInitConfig?]): Tensor;
+};
+
+export * from "@/core";

--- a/packages/web/src/utils.ts
+++ b/packages/web/src/utils.ts
@@ -1,0 +1,75 @@
+import { NestedNumberList } from "@/types";
+
+export function inferShapeFromNestedArray(arr: NestedNumberList): number[] {
+  if (!Array.isArray(arr)) {
+    // Base case: number
+    return [];
+  }
+
+  if (!Array.isArray(arr[0])) {
+    // Base case: array of numbers
+    return [arr.length];
+  }
+
+  if (arr.length === 0) return [0];
+
+  // Get shape of first element
+  const restShape = inferShapeFromNestedArray(arr[0]);
+
+  // Verify all elements have the same shape
+  for (let i = 1; i < arr.length; i++) {
+    const shape = inferShapeFromNestedArray(arr[i]);
+    if (shape.length !== restShape.length) {
+      throw new Error("Inconsistent dimensions in nested array");
+    }
+    for (let j = 0; j < shape.length; j++) {
+      if (shape[j] !== restShape[j]) {
+        throw new Error("Inconsistent dimensions in nested array");
+      }
+    }
+  }
+
+  // Return the full shape: [this level's length, ...shape of elements]
+  return [arr.length, ...restShape];
+}
+
+/**
+ * A handle which provides the capability to remove a hook.
+ *
+ * This class generates unique IDs for hooks and provides methods to cleanly
+ * remove hooks from their associated collections.
+ */
+export class RemovableHandle {
+  /** The unique ID of this handle */
+  id: number;
+
+  private hooksMap: WeakRef<Map<number, unknown>>;
+  private static nextId: number = 0;
+
+  /**
+   * Creates a new removable handle
+   *
+   * @param hooksMap - The primary map of hooks indexed by hook ID
+   */
+  constructor(hooksMap: Map<number, unknown>) {
+    // Assign a unique ID from the static counter
+    this.id = RemovableHandle.nextId++;
+
+    // Store weak references to avoid potential memory leaks
+    this.hooksMap = new WeakRef(hooksMap);
+
+    // Set this ID in the hooks map
+    hooksMap.set(this.id, null);
+  }
+
+  /**
+   * Removes the hook from all associated collections
+   */
+  remove(): void {
+    // Get the actual map from the weak reference
+    const hooksMap = this.hooksMap.deref();
+    if (hooksMap && hooksMap.has(this.id)) {
+      hooksMap.delete(this.id);
+    }
+  }
+}

--- a/packages/web/src/wasm.ts
+++ b/packages/web/src/wasm.ts
@@ -1,0 +1,15 @@
+export {
+  cpu as cpu_wasm,
+  Device,
+  DType,
+  float16 as float16_wasm,
+  float32 as float32_wasm,
+  gpu as gpu_wasm,
+  int32 as int32_wasm,
+  save as save_wasm,
+  seed as seed_wasm,
+  Tensor as Tensor_wasm,
+  Trainer as Trainer_wasm,
+  uint32 as uint32_wasm,
+  default as wasmInit,
+} from "@piston/piston-web";

--- a/packages/web/tsconfig.json
+++ b/packages/web/tsconfig.json
@@ -1,0 +1,34 @@
+{
+  "compilerOptions": {
+    "target": "es2020",
+    "module": "esnext",
+    "lib": ["dom", "esnext"],
+    "importHelpers": true,
+    "declaration": true,
+    "rootDir": "./src",
+    "outDir": "./dist",
+    "strict": true,
+    "noImplicitAny": true,
+    "noImplicitThis": true,
+    "alwaysStrict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "moduleResolution": "node",
+    "baseUrl": "./",
+    "paths": {
+      "@/*": ["src/*"],
+      "@piston/piston-web": ["../../target/pkg/piston-web"]
+    },
+    "preserveSymlinks": true,
+    "jsx": "react",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    // We do this because we don't want to include the Node.js Buffer type (or others, really)
+    "types": []
+  },
+  "include": ["src", "../../target/pkg/piston-web/piston-web.d.ts"],
+  "exclude": ["node_modules", "dist", "test"]
+}


### PR DESCRIPTION
Add flexible PyTorch-like JS interfaces to make it easier to configure models on the web. This notably includes an alternative API to `piston-nn`.